### PR TITLE
feat: soften form row backgrounds

### DIFF
--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -244,6 +244,53 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         }
     }
 
+    /// Standardized background for grouped form rows.
+    /// - Parameter colorScheme: The environment color scheme used for dynamic overrides.
+    func formRowBackground(for colorScheme: ColorScheme) -> Color {
+        switch self {
+        case .system where colorScheme == .light:
+            return Color(UIColor { trait in
+                if trait.userInterfaceStyle == .dark {
+                    return UIColor.secondarySystemBackground
+                } else {
+                    return UIColor(red: 0.94, green: 0.95, blue: 0.96, alpha: 1.0)
+                }
+            })
+        case .classic:
+            return Color(UIColor { trait in
+                if trait.userInterfaceStyle == .dark {
+                    return UIColor.secondarySystemGroupedBackground
+                } else {
+                    return UIColor(red: 0.93, green: 0.94, blue: 0.95, alpha: 1.0)
+                }
+            })
+        default:
+            let brightness = AppThemeColorUtilities.hsba(from: background)?.brightness ?? (colorScheme == .dark ? 0.25 : 0.85)
+            let blendAmount: Double
+            switch brightness {
+            case ..<0.25:
+                blendAmount = 0.28
+            case ..<0.45:
+                blendAmount = 0.20
+            case ..<0.65:
+                blendAmount = 0.14
+            case ..<0.85:
+                blendAmount = 0.10
+            default:
+                blendAmount = 0.08
+            }
+
+            let wash = AppThemeColorUtilities.adjust(
+                resolvedTint,
+                saturationMultiplier: colorScheme == .dark ? 0.35 : 0.22,
+                brightnessMultiplier: colorScheme == .dark ? 0.72 : 1.16,
+                alpha: 1.0
+            )
+
+            return AppThemeColorUtilities.mix(background, wash, amount: blendAmount)
+        }
+    }
+
     /// Tertiary background for card shells.
     var tertiaryBackground: Color {
         switch self {

--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -48,6 +48,7 @@ struct EditSheetScaffold<Content: View>: View {
 
     // MARK: Environment
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var themeManager: ThemeManager
 
     // Selection state for detents (compat type)
@@ -157,7 +158,7 @@ struct EditSheetScaffold<Content: View>: View {
     // MARK: Row Background
     private var rowBackground: some View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(themeManager.selectedTheme.secondaryBackground)
+            .fill(themeManager.selectedTheme.formRowBackground(for: colorScheme))
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(separatorColor, lineWidth: 1)

--- a/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
+++ b/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
@@ -21,6 +21,7 @@ struct ExpenseCategoryManagerView: View {
     // MARK: Dependencies
     @Environment(\.managedObjectContext) private var viewContext
     @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isOnboardingPresentation) private var isOnboardingPresentation
 
     // MARK: Sorting (extracted to avoid heavy type inference)
@@ -101,7 +102,7 @@ struct ExpenseCategoryManagerView: View {
                     Section {
                         ForEach(categories, id: \.objectID) { category in
                             categoryRow(for: category)
-                                .listRowBackground(themeManager.selectedTheme.secondaryBackground)
+                                .listRowBackground(themeManager.selectedTheme.formRowBackground(for: colorScheme))
                         }
                         .onDelete { offsets in
                             let targets = offsets.map { categories[$0] }
@@ -116,7 +117,7 @@ struct ExpenseCategoryManagerView: View {
                     } footer: {
                         Text("These categories appear when adding unplanned expenses. Colors help visually group spending.")
                     }
-                    .listRowBackground(themeManager.selectedTheme.secondaryBackground)
+                    .listRowBackground(themeManager.selectedTheme.formRowBackground(for: colorScheme))
                 }
                 .listStyle(.insetGrouped)
                 .applyIfAvailableScrollContentBackgroundHidden()


### PR DESCRIPTION
## Summary
- add an AppTheme.formRowBackground helper that derives tint-aware form fills with explicit overrides for System-light and Classic
- update EditSheetScaffold and the expense category editor list to consume the helper so themed sheets share the new fill

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd699c25e8832cb3a40a33e60753b0