### PR TITLE
fix: harmonize legacy navigation tint fallback

### DIFF
--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -563,6 +563,53 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         })
     }
 
+    /// Base fill color used when Liquid Glass isn't available. Ensures legacy
+    /// surfaces share the same tint as navigation chrome.
+    var legacySurfaceFillColor: Color {
+        switch self {
+        case .system:
+            return background
+        default:
+            return glassBaseColor
+        }
+    }
+
+    /// Navigation bar background shape style for legacy OS versions that do
+    /// not support glass surfaces.
+    @available(iOS 16.0, macCatalyst 16.0, *)
+    var legacyNavigationFallbackStyle: AnyShapeStyle {
+        if self == .system {
+            return AnyShapeStyle(legacyChromeBackground)
+        }
+
+        let base = legacySurfaceFillColor
+        let highlight = AppThemeColorUtilities.adjust(
+            base,
+            saturationMultiplier: 0.94,
+            brightnessMultiplier: 1.08,
+            alpha: 1.0
+        )
+        let shadow = AppThemeColorUtilities.adjust(
+            base,
+            saturationMultiplier: 1.04,
+            brightnessMultiplier: 0.94,
+            alpha: 1.0
+        )
+
+        return AnyShapeStyle(
+            LinearGradient(
+                gradient: Gradient(stops: [
+                    .init(color: highlight, location: 0.0),
+                    .init(color: base, location: 0.42),
+                    .init(color: shadow, location: 0.78),
+                    .init(color: base, location: 1.0)
+                ]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+
     /// UIKit helper for legacy chrome background.
     func legacyUIKitChromeBackgroundColor(colorScheme: ColorScheme?) -> UIColor {
         let trait: UIUserInterfaceStyle

--- a/OffshoreBudgeting/Systems/Compatibility.swift
+++ b/OffshoreBudgeting/Systems/Compatibility.swift
@@ -449,7 +449,7 @@ private struct UBSurfaceBackgroundModifier: ViewModifier {
             )
         } else {
             content.background(
-                theme.background.ub_ignoreSafeArea(edges: ignoresSafeAreaEdges)
+                theme.legacySurfaceFillColor.ub_ignoreSafeArea(edges: ignoresSafeAreaEdges)
             )
         }
     }
@@ -535,9 +535,16 @@ private struct UBNavigationBackgroundModifier: ViewModifier {
             )
         } else {
             if #available(iOS 16.0, *) {
+                let fallbackStyle: AnyShapeStyle
+                if theme == .system {
+                    fallbackStyle = AnyShapeStyle(theme.legacyChromeBackground)
+                } else {
+                    fallbackStyle = theme.legacyNavigationFallbackStyle
+                }
+
                 content
                     .toolbarBackground(.visible, for: .navigationBar)
-                    .toolbarBackground(theme.legacyChromeBackground, for: .navigationBar)
+                    .toolbarBackground(fallbackStyle, for: .navigationBar)
                     .toolbarColorScheme(colorScheme == .dark ? .dark : .light, for: .navigationBar)
             } else {
                 content


### PR DESCRIPTION
## Summary
- add AppTheme helpers that reuse the glass tint for legacy surfaces and navigation chrome
- switch legacy navigation backgrounds to the new shape style while keeping system chrome behavior
- align non-glass surface backgrounds with the shared tint so navigation and content blend together

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd7fabe764832c955be166a2c88fad