### PR TITLE
fix: disable neutral translucent button shadow

### DIFF
--- a/OffshoreBudgeting/Views/Components/TranslucentButtonStyle.swift
+++ b/OffshoreBudgeting/Views/Components/TranslucentButtonStyle.swift
@@ -229,6 +229,10 @@ struct TranslucentButtonStyle: ButtonStyle {
     }
 
     private func shadowColor(for theme: AppTheme, isPressed: Bool) -> Color {
+        if appearance == .neutral {
+            return .clear
+        }
+
         if usesSystemPalette(for: theme) {
             return Color.black.opacity(isPressed ? 0.20 : 0.28)
         } else {


### PR DESCRIPTION
## Summary
- return a clear drop shadow color for the neutral translucent button appearance so neutral buttons render without glow

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df06e3a018832caf45c658ab64a483