### PR TITLE
Add reusable glass CTA helper for add expense empty states

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -95,17 +95,12 @@ struct AddPlannedExpenseView: View {
                         Text("No cards yet. Add one to assign this expense.")
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                        Button {
-                            isPresentingAddCard = true
-                        } label: {
+                        GlassCTAButton(
+                            fallbackAppearance: .neutral,
+                            action: { isPresentingAddCard = true }
+                        ) {
                             Label("Add Card", systemImage: "plus")
                         }
-                        .buttonStyle(
-                            TranslucentButtonStyle(
-                                tint: themeManager.selectedTheme.resolvedTint,
-                                appearance: .neutral
-                            )
-                        )
                         .accessibilityLabel("Add Card")
                     }
                 } else {

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -71,17 +71,12 @@ struct AddUnplannedExpenseView: View {
                         Text("No cards yet. Add one to assign this expense.")
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                        Button {
-                            isPresentingAddCard = true
-                        } label: {
+                        GlassCTAButton(
+                            fallbackAppearance: .neutral,
+                            action: { isPresentingAddCard = true }
+                        ) {
                             Label("Add Card", systemImage: "plus")
                         }
-                        .buttonStyle(
-                            TranslucentButtonStyle(
-                                tint: themeManager.selectedTheme.resolvedTint,
-                                appearance: .neutral
-                            )
-                        )
                         .accessibilityLabel("Add Card")
                     }
                 } else {

--- a/OffshoreBudgeting/Views/Components/GlassCTAButton.swift
+++ b/OffshoreBudgeting/Views/Components/GlassCTAButton.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+// MARK: - GlassCTAButton
+/// Reusable call-to-action button that automatically adopts the Liquid Glass
+/// treatment on modern systems while falling back to the legacy translucent
+/// styling for older platforms.
+struct GlassCTAButton<Label: View>: View {
+    @Environment(\.platformCapabilities) private var capabilities
+    @EnvironmentObject private var themeManager: ThemeManager
+
+    private let maxWidth: CGFloat?
+    private let action: () -> Void
+    private let labelBuilder: () -> Label
+    private let fallbackAppearance: TranslucentButtonStyle.Appearance
+    private let fallbackMetrics: TranslucentButtonStyle.Metrics
+
+    init(
+        maxWidth: CGFloat? = nil,
+        fallbackAppearance: TranslucentButtonStyle.Appearance = .tinted,
+        fallbackMetrics: TranslucentButtonStyle.Metrics = .standard,
+        action: @escaping () -> Void,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.maxWidth = maxWidth
+        self.action = action
+        self.labelBuilder = label
+        self.fallbackAppearance = fallbackAppearance
+        self.fallbackMetrics = fallbackMetrics
+    }
+
+    var body: some View {
+        Group {
+            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
+                glassButton()
+            } else {
+                legacyButton()
+            }
+        }
+        .frame(maxWidth: maxWidth)
+    }
+
+    // MARK: - Private Helpers
+    @ViewBuilder
+    private func legacyButton() -> some View {
+        Button(action: action) {
+            labelBuilder()
+        }
+        .buttonStyle(
+            TranslucentButtonStyle(
+                tint: fallbackTint,
+                metrics: fallbackMetrics,
+                appearance: fallbackAppearance
+            )
+        )
+    }
+
+    @available(iOS 26.0, macCatalyst 26.0, *)
+    @ViewBuilder
+    private func glassButton() -> some View {
+        let capsule = Capsule(style: .continuous)
+
+        GlassEffectContainer {
+            Button(action: action) {
+                labelBuilder()
+                    .font(.system(size: 17, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.primary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, DS.Spacing.xl)
+                    .padding(.vertical, DS.Spacing.m)
+                    .contentShape(capsule)
+            }
+            .buttonStyle(.plain)
+            .tint(glassTint)
+            .glassEffect(in: capsule)
+        }
+    }
+
+    private var fallbackTint: Color {
+        themeManager.selectedTheme.resolvedTint
+    }
+
+    private var glassTint: Color {
+        themeManager.selectedTheme.glassPalette.accent
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `GlassCTAButton` helper that adopts the Liquid Glass CTA styling with a legacy fallback
- update the planned and unplanned expense empty states to use the new helper so the “+ Add Card” button matches presets

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df0a328f28832c88ffa88d5526be31