### PR TITLE
feat(view): wrap glass CTA in capsule container

### DIFF
--- a/OffshoreBudgeting/Views/Components/GlassCTAButton.swift
+++ b/OffshoreBudgeting/Views/Components/GlassCTAButton.swift
@@ -57,21 +57,18 @@ struct GlassCTAButton<Label: View>: View {
     @available(iOS 26.0, macCatalyst 26.0, *)
     @ViewBuilder
     private func glassButton() -> some View {
-        let capsule = Capsule(style: .continuous)
-
-        GlassEffectContainer {
+        GlassCapsuleContainer(
+            horizontalPadding: DS.Spacing.xl,
+            verticalPadding: DS.Spacing.m,
+            alignment: .center
+        ) {
             Button(action: action) {
                 labelBuilder()
                     .font(.system(size: 17, weight: .semibold, design: .rounded))
                     .foregroundStyle(.primary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, DS.Spacing.xl)
-                    .padding(.vertical, DS.Spacing.m)
-                    .contentShape(capsule)
             }
             .buttonStyle(.plain)
             .tint(glassTint)
-            .glassEffect(in: capsule)
         }
     }
 


### PR DESCRIPTION
## Summary
- wrap the modern GlassCTAButton path in GlassCapsuleContainer to reuse shared layout and effect handling
- remove redundant frame and padding modifiers from the label while keeping button styling consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df11074e1c832cbe7b14f782699b3d