### PR TITLE
fix: align home category control height

### DIFF
--- a/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
+++ b/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
@@ -12,7 +12,7 @@ struct CategoryTotalsRow: View {
     let categories: [BudgetSummary.CategorySpending]
     var isPlaceholder: Bool = false
     var horizontalInset: CGFloat = DS.Spacing.l
-    private let controlHeight: CGFloat = 34
+    private let controlHeight: CGFloat = 44
     @Environment(\.platformCapabilities) private var capabilities
     @EnvironmentObject private var themeManager: ThemeManager
     @Namespace private var glassNamespace

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -334,7 +334,10 @@ struct HomeView: View {
                             Button(action: addExpenseCTAAction) {
                                 Label(addExpenseCTATitle, systemImage: "plus")
                                     .font(.system(size: 17, weight: .semibold, design: .rounded))
-                                    .frame(maxWidth: .infinity)
+                                    .frame(
+                                maxWidth: .infinity,
+                                minHeight: HomeHeaderOverviewMetrics.categoryControlHeight
+                            )
                                     .frame(minHeight: 44)
                             }
                             .buttonStyle(.glass)
@@ -683,7 +686,10 @@ private struct HomeHeaderOverviewTable: View {
                     Button(action: onAddCategory) {
                         Label("Add Category", systemImage: "plus")
                             .font(.system(size: 16, weight: .semibold, design: .rounded))
-                            .frame(maxWidth: .infinity)
+                            .frame(
+                                maxWidth: .infinity,
+                                minHeight: HomeHeaderOverviewMetrics.categoryControlHeight
+                            )
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("home_add_category_cta")
@@ -850,7 +856,7 @@ private enum HomeHeaderOverviewMetrics {
     static let metricRowSpacing: CGFloat = DS.Spacing.xs
     static let metricGroupSpacing: CGFloat = DS.Spacing.xs
     static let categoryChipTopSpacing: CGFloat = DS.Spacing.s
-    static let categoryControlHeight: CGFloat = 34
+    static let categoryControlHeight: CGFloat = 44
     static let controlHorizontalPadding: CGFloat = DS.Spacing.s
     static let controlVerticalPadding: CGFloat = DS.Spacing.s
     static let titleFont: Font = .largeTitle.bold()


### PR DESCRIPTION
## Summary
- raise the Home header category control height to 44pt and ensure the CTA respects the new size
- bump CategoryTotalsRow chip height to 44pt across liquid glass and legacy presentations for alignment

## Testing
- not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68dfd1954428832cbc57b7fca54ba9be