### PR TITLE
Expand glass CTA button fill behavior

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -96,6 +96,8 @@ struct AddPlannedExpenseView: View {
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         GlassCTAButton(
+                            maxWidth: .infinity,
+                            fillHorizontally: true,
                             fallbackAppearance: .neutral,
                             action: { isPresentingAddCard = true }
                         ) {

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -72,6 +72,8 @@ struct AddUnplannedExpenseView: View {
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         GlassCTAButton(
+                            maxWidth: .infinity,
+                            fillHorizontally: true,
                             fallbackAppearance: .neutral,
                             action: { isPresentingAddCard = true }
                         ) {


### PR DESCRIPTION
## Summary
- teach `GlassCTAButton` to resolve a light-mode foreground and support optional horizontal fill on modern glass
- update planned and unplanned expense forms to request the expanded "Add Card" call-to-action

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dfd654d6dc832c8b8b2cc455f52bef