### PR TITLE
fix: enable card motion shine only on selected card

### DIFF
--- a/OffshoreBudgeting/Views/CardPickerRow.swift
+++ b/OffshoreBudgeting/Views/CardPickerRow.swift
@@ -53,7 +53,7 @@ struct CardPickerRow: View {
                         // MARK: On Tap → Select for Expense
                         selectedCardID = managedCard.objectID
                         },
-                        enableMotionShine: isSelected,
+                        enableMotionShine: true,
                         showsBaseShadow: false
                     )
                     .frame(height: tileHeight)

--- a/OffshoreBudgeting/Views/CardPickerRow.swift
+++ b/OffshoreBudgeting/Views/CardPickerRow.swift
@@ -44,15 +44,16 @@ struct CardPickerRow: View {
                     // MARK: Bridge Core Data → UI model
                     // Uses your existing CoreDataBridge to pull name/theme.
                     let item = CardItem(from: managedCard)
+                    let isSelected = selectedCardID == managedCard.objectID
 
                     CardTileView(
                         card: item,
-                        isSelected: selectedCardID == managedCard.objectID,
+                        isSelected: isSelected,
                         onTap: {
                         // MARK: On Tap → Select for Expense
                         selectedCardID = managedCard.objectID
                         },
-                        enableMotionShine: false,
+                        enableMotionShine: isSelected,
                         showsBaseShadow: false
                     )
                     .frame(height: tileHeight)


### PR DESCRIPTION
## Summary
- update CardPickerRow so CardTileView enables motion shine exclusively for the selected card
- keep unselected cards static to reduce motion load

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfdcd46ac8832c938f3145b7af18e8