### PR TITLE
Fix BudgetDetailsView legacy list row backgrounds

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -976,7 +976,7 @@ private struct PlannedListFR: View {
                     bottom: 12
                 )
             )
-            .ub_preOS26ListRowBackground(themeManager.selectedTheme.secondaryBackground)
+            .ub_preOS26ListRowBackground(themeManager.selectedTheme.background)
             .contentShape(Rectangle())
             .unifiedSwipeActions(
                 UnifiedSwipeConfig(allowsFullSwipeToDelete: false),
@@ -1013,7 +1013,7 @@ private struct PlannedListFR: View {
                     : EdgeInsets()
             )
             .listRowSeparator(.hidden)
-            .ub_preOS26ListRowBackground(themeManager.selectedTheme.secondaryBackground)
+            .ub_preOS26ListRowBackground(themeManager.selectedTheme.background)
     }
 
     @ViewBuilder
@@ -1105,7 +1105,7 @@ private struct BudgetListRowContainer<Content: View>: View {
             .padding(.leading, horizontalInsets.leading)
             .padding(.trailing, horizontalInsets.trailing)
             .listRowBackground(Color.clear)
-            .ub_preOS26ListRowBackground(themeManager.selectedTheme.secondaryBackground)
+            .ub_preOS26ListRowBackground(themeManager.selectedTheme.background)
     }
 }
 
@@ -1311,7 +1311,7 @@ private struct VariableListFR: View {
                     bottom: 12
                 )
             )
-            .ub_preOS26ListRowBackground(themeManager.selectedTheme.secondaryBackground)
+            .ub_preOS26ListRowBackground(themeManager.selectedTheme.background)
             .contentShape(Rectangle())
             .unifiedSwipeActions(
                 UnifiedSwipeConfig(allowsFullSwipeToDelete: false),


### PR DESCRIPTION
## Summary
- update BudgetDetailsView pre-iOS 26 list row backgrounds to use the theme background color
- ensure sticky header rows share the same legacy background handling for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dffaf28a04832c891248fcbf265659