### PR TITLE
feat: align income layout with responsive inset

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootTabPageScaffold.swift
+++ b/OffshoreBudgeting/Views/Components/RootTabPageScaffold.swift
@@ -410,6 +410,23 @@ struct RootTabPageProxy {
     }
 }
 
+extension RootTabPageProxy {
+    /// Resolves the recommended symmetric horizontal inset for root tab content.
+    ///
+    /// - Parameters:
+    ///   - capabilities: Platform capabilities that gate OS 26 visual treatments.
+    /// - Returns: ``RootTabHeaderLayout.defaultHorizontalPadding`` when OS 26
+    ///   visuals are active or the layout is wide (≥600pt). Falls back to the
+    ///   leading safe-area inset on compact legacy layouts so content can align
+    ///   flush with the device edges.
+    func resolvedSymmetricHorizontalInset(capabilities: PlatformCapabilities) -> CGFloat {
+        if capabilities.supportsOS26Translucency { return RootTabHeaderLayout.defaultHorizontalPadding }
+        if layoutContext.containerSize.width >= 600 { return RootTabHeaderLayout.defaultHorizontalPadding }
+
+        return max(effectiveSafeAreaInsets.leading, 0)
+    }
+}
+
 // MARK: - Preference Infrastructure
 private enum RootTabSection: Hashable {
     case header

--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -205,6 +205,7 @@ struct IncomeView: View {
     private func landscapeLayout(using proxy: RootTabPageProxy, availableHeight: CGFloat) -> some View {
         let minimums = minimumCardHeights(using: proxy)
         let gutter = proxy.compactAwareTabBarGutter
+        let horizontalInset = proxy.resolvedSymmetricHorizontalInset(capabilities: capabilities)
         let heights = adaptiveCardHeights(
             using: proxy,
             availableHeight: availableHeight,
@@ -219,7 +220,7 @@ struct IncomeView: View {
             rightColumnHeight - (calendarSectionContentPadding * 2) - navigationHeaderHeight,
             minimums.calendar
         )
-        let horizontalPadding = DS.Spacing.l * 2
+        let horizontalPadding = horizontalInset * 2
         let columnSpacing = DS.Spacing.l
         let availableWidth = max(proxy.layoutContext.containerSize.width - horizontalPadding - columnSpacing, 0)
         let calendarFraction: CGFloat = 0.58
@@ -243,7 +244,7 @@ struct IncomeView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .rootTabContentPadding(
             proxy,
-            horizontal: DS.Spacing.l,
+            horizontal: horizontalInset,
             includeSafeArea: false,
             tabBarGutter: gutter
         )
@@ -256,6 +257,7 @@ struct IncomeView: View {
     private func nonScrollingLayout(using proxy: RootTabPageProxy, availableHeight: CGFloat) -> some View {
         let minimums = minimumCardHeights(using: proxy)
         let gutter = proxy.compactAwareTabBarGutter
+        let horizontalInset = proxy.resolvedSymmetricHorizontalInset(capabilities: capabilities)
         let heights = adaptiveCardHeights(
             using: proxy,
             availableHeight: availableHeight,
@@ -276,7 +278,7 @@ struct IncomeView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .rootTabContentPadding(
             proxy,
-            horizontal: DS.Spacing.l,
+            horizontal: horizontalInset,
             includeSafeArea: false,
             tabBarGutter: gutter
         )
@@ -289,6 +291,7 @@ struct IncomeView: View {
     private func scrollingLayout(using proxy: RootTabPageProxy) -> some View {
         let minimums = minimumCardHeights(using: proxy)
         let gutter = proxy.compactAwareTabBarGutter
+        let horizontalInset = proxy.resolvedSymmetricHorizontalInset(capabilities: capabilities)
 
         return ScrollView(showsIndicators: false) {
             VStack(spacing: DS.Spacing.m) {
@@ -301,7 +304,7 @@ struct IncomeView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .rootTabContentPadding(
                 proxy,
-                horizontal: DS.Spacing.l,
+                horizontal: horizontalInset,
                 includeSafeArea: false,
                 tabBarGutter: gutter
             )


### PR DESCRIPTION
## Summary
- add a RootTabPageProxy helper that resolves responsive horizontal padding based on platform capabilities
- update IncomeView layouts to use the helper for width math and rootTabContentPadding so legacy compact screens respect safe-area edges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0062854cc832c8fa995d6c8b45dbc