### PR TITLE
fix: normalize Presets scaffold layout

### DIFF
--- a/OffshoreBudgeting/Views/PresetsView.swift
+++ b/OffshoreBudgeting/Views/PresetsView.swift
@@ -34,7 +34,7 @@ struct PresetsView: View {
         RootTabPageScaffold(
             scrollBehavior: .always,
             spacing: DS.Spacing.s,
-            wrapsContentInScrollView: !capabilities.supportsOS26Translucency
+            wrapsContentInScrollView: false
         ) {
             EmptyView()
         } content: { proxy in
@@ -59,6 +59,8 @@ struct PresetsView: View {
 
     @ViewBuilder
     private func content(using proxy: RootTabPageProxy) -> some View {
+        let horizontalInset = proxy.resolvedSymmetricHorizontalInset(capabilities: capabilities)
+
         Group {
             // MARK: Empty State — standardized with UBEmptyState (same as Home/Cards)
             if viewModel.items.isEmpty {
@@ -69,9 +71,12 @@ struct PresetsView: View {
                     primaryButtonTitle: "Add Preset",
                     onPrimaryTap: { isPresentingAddSheet = true }
                 )
-                .padding(.horizontal, DS.Spacing.l)
+                .padding(.horizontal, horizontalInset)
                 .frame(maxWidth: .infinity)
-                .frame(minHeight: proxy.availableHeightBelowHeader, alignment: .center)
+                .frame(
+                    minHeight: max(proxy.availableHeightBelowHeader, proxy.availableHeight),
+                    alignment: .center
+                )
             } else {
                 // MARK: Non-empty List
                 List {
@@ -82,7 +87,9 @@ struct PresetsView: View {
                                 sheetTemplateToAssign = template
                             }
                         )
-                        .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+                        .listRowInsets(
+                            EdgeInsets(top: 12, leading: horizontalInset, bottom: 12, trailing: horizontalInset)
+                        )
                         .ub_preOS26ListRowBackground(themeManager.selectedTheme.secondaryBackground)
                         .unifiedSwipeActions(
                             UnifiedSwipeConfig(allowsFullSwipeToDelete: false),


### PR DESCRIPTION
## Summary
- stop wrapping Presets content in the scaffold scroll view so legacy lists manage their own scrolling
- reuse the responsive horizontal inset for both the empty state and list row insets
- clamp the empty state height so the primary button stays visible across OS versions

## Testing
- not run (not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68e009a14484832cab6280d4a2c8d65b