### PR TITLE
Fix: add top gap before Settings cards

### DIFF
--- a/OffshoreBudgeting/Views/SettingsView.swift
+++ b/OffshoreBudgeting/Views/SettingsView.swift
@@ -263,6 +263,7 @@ struct SettingsView: View {
         .rootTabContentPadding(
             proxy,
             horizontal: horizontalInset,
+            extraTop: DS.Spacing.s,
             extraBottom: extraBottomPadding(
                 using: proxy,
                 tabBarGutter: tabBarGutter


### PR DESCRIPTION
## Summary
- add a small top padding offset to the Settings tab content so the first card clears the header planes
- retain the existing scroll view top padding to keep header spacing consistent across tabs

## Testing
- not run (UI spacing change)


------
https://chatgpt.com/codex/tasks/task_e_68e014417eec832c9f53bca531485f7a