### PR TITLE
Adjust header icon font weight to system default

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -63,7 +63,7 @@ struct RootHeaderControlIcon: View {
 
     var body: some View {
         configuredImage
-            .font(.system(size: 18, weight: .semibold))
+            .font(.system(size: 18, weight: .regular, design: .default))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .foregroundStyle(iconForegroundStyle)
     }


### PR DESCRIPTION
## Summary
- align RootHeaderControlIcon symbol font weight with the standard system design so HomeView icons match IncomeView

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0363a81a8832c8c34d4d8ebde9547