### PR TITLE
fix: align OS26 header menu glass control

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -830,12 +830,10 @@ private struct HeaderMenuGlassLabel: View {
 
     var body: some View {
         if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-            RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)
-                .frame(
-                    width: RootHeaderActionMetrics.iconDimension(for: capabilities, width: nil),
-                    height: RootHeaderActionMetrics.iconDimension(for: capabilities, width: nil)
-                )
-                .tint(themeManager.selectedTheme.resolvedTint)
+            RootHeaderGlassControl(sizing: .icon) {
+                RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)
+            }
+            .tint(themeManager.selectedTheme.resolvedTint)
         } else {
             RootHeaderGlassControl(sizing: .icon) {
                 RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)


### PR DESCRIPTION
## Summary
- update the OS26 header menu label to reuse the shared RootHeaderGlassControl capsule path
- keep the theme tint applied to the icon and rely on RootHeaderActionMetrics for minimum sizing compliance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e036fb8558832c8a04168447e1989d