### PR TITLE
feat: animate home toolbar glass capsules

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -53,6 +53,30 @@ enum RootHeaderControlSizing {
     case icon
 }
 
+enum RootHeaderGlassTransitionStyle {
+    case matchedGeometry
+    case materialize
+}
+
+struct RootHeaderGlassEffectConfiguration {
+    let namespace: Namespace.ID
+    let id: String
+    let unionID: String?
+    let transition: RootHeaderGlassTransitionStyle
+
+    init(
+        namespace: Namespace.ID,
+        id: String,
+        unionID: String? = nil,
+        transition: RootHeaderGlassTransitionStyle = .matchedGeometry
+    ) {
+        self.namespace = namespace
+        self.id = id
+        self.unionID = unionID
+        self.transition = transition
+    }
+}
+
 // MARK: - Icon Content
 struct RootHeaderControlIcon: View {
     @EnvironmentObject private var themeManager: ThemeManager
@@ -509,6 +533,42 @@ struct RootHeaderGlassPill<Leading: View, Trailing: View, Secondary: View>: View
     }
 }
 
+private extension View {
+    @ViewBuilder
+    func applyGlassEffectConfiguration(
+        _ configuration: RootHeaderGlassEffectConfiguration?
+    ) -> some View {
+        if let configuration,
+           #available(iOS 26.0, macCatalyst 26.0, *) {
+            let withID = glassEffectID(configuration.id, in: configuration.namespace)
+
+            if let unionID = configuration.unionID {
+                withID
+                    .glassEffectUnion(id: unionID, namespace: configuration.namespace)
+                    .applyGlassTransition(configuration.transition)
+            } else {
+                withID
+                    .applyGlassTransition(configuration.transition)
+            }
+        } else {
+            self
+        }
+    }
+}
+
+@available(iOS 26.0, macCatalyst 26.0, *)
+private extension View {
+    @ViewBuilder
+    func applyGlassTransition(_ style: RootHeaderGlassTransitionStyle) -> some View {
+        switch style {
+        case .matchedGeometry:
+            glassEffectTransition(.matchedGeometry)
+        case .materialize:
+            glassEffectTransition(.materialize)
+        }
+    }
+}
+
 struct RootHeaderGlassControl<Content: View>: View {
     @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.platformCapabilities) private var capabilities
@@ -516,15 +576,18 @@ struct RootHeaderGlassControl<Content: View>: View {
     private let content: Content
     private let width: CGFloat?
     private let sizing: RootHeaderControlSizing
+    private let glassEffectConfiguration: RootHeaderGlassEffectConfiguration?
 
     init(
         width: CGFloat? = nil,
         sizing: RootHeaderControlSizing = .automatic,
+        glassEffectConfiguration: RootHeaderGlassEffectConfiguration? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.content = content()
         self.width = width
         self.sizing = sizing
+        self.glassEffectConfiguration = glassEffectConfiguration
     }
 
     @ViewBuilder
@@ -541,26 +604,31 @@ struct RootHeaderGlassControl<Content: View>: View {
                 if #available(iOS 26.0, macCatalyst 26.0, *) {
                     RootHeaderGlassCapsuleContainer {
                         content
+                            .applyGlassEffectConfiguration(glassEffectConfiguration)
                             .frame(width: iconSide, height: iconSide)
                     }
                     .contentShape(Circle())
                 } else {
                     content
+                        .applyGlassEffectConfiguration(glassEffectConfiguration)
                         .frame(width: fallbackSide, height: fallbackSide)
                         .contentShape(Circle())
                 }
             } else {
                 content
+                    .applyGlassEffectConfiguration(glassEffectConfiguration)
                     .frame(width: fallbackSide, height: fallbackSide)
                     .contentShape(Circle())
             }
 #else
             content
+                .applyGlassEffectConfiguration(glassEffectConfiguration)
                 .frame(width: fallbackSide, height: fallbackSide)
                 .contentShape(Circle())
 #endif
         } else {
             content
+                .applyGlassEffectConfiguration(glassEffectConfiguration)
                 .modifier(RootHeaderGlassControlFrameModifier(width: width, dimension: dimension))
                 .contentShape(Rectangle())
                 .padding(.horizontal, RootHeaderGlassMetrics.horizontalPadding)

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -41,6 +41,7 @@ struct HomeView: View {
     @State private var isPresentingManageCards: Bool = false
     @State private var isPresentingManagePresets: Bool = false
     @State private var isPresentingManageCategories: Bool = false
+    @Namespace private var headerGlassNamespace
 
     // MARK: Body
     @EnvironmentObject private var themeManager: ThemeManager
@@ -161,7 +162,12 @@ struct HomeView: View {
                 Button(period.displayName) { budgetPeriodRawValue = period.rawValue }
             }
         } label: {
-            HeaderMenuGlassLabel(systemImage: "calendar")
+            HeaderMenuGlassLabel(
+                systemImage: "calendar",
+                glassNamespace: headerGlassNamespace,
+                glassEffectID: HomeToolbarGlassEffectID.calendar,
+                glassEffectUnionID: HomeToolbarGlassEffectID.union
+            )
                 .accessibilityLabel(budgetPeriod.displayName)
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -172,7 +178,14 @@ struct HomeView: View {
         Menu {
             Button("Add Planned Expense") { isPresentingAddPlannedFromHome = true }
             Button("Add Variable Expense") { isPresentingAddVariableFromHome = true }
-        } label: { HeaderMenuGlassLabel(systemImage: "plus") }
+        } label: {
+            HeaderMenuGlassLabel(
+                systemImage: "plus",
+                glassNamespace: headerGlassNamespace,
+                glassEffectID: HomeToolbarGlassEffectID.add,
+                glassEffectUnionID: HomeToolbarGlassEffectID.union
+            )
+        }
         .modifier(HideMenuIndicatorIfPossible())
         .accessibilityLabel("Add Expense")
     }
@@ -185,7 +198,14 @@ struct HomeView: View {
             Button("Add Variable Expense") {
                 triggerAddExpense(.budgetDetailsRequestAddVariableExpense, budgetID: budgetID)
             }
-        } label: { HeaderMenuGlassLabel(systemImage: "plus") }
+        } label: {
+            HeaderMenuGlassLabel(
+                systemImage: "plus",
+                glassNamespace: headerGlassNamespace,
+                glassEffectID: HomeToolbarGlassEffectID.add,
+                glassEffectUnionID: HomeToolbarGlassEffectID.union
+            )
+        }
         .modifier(HideMenuIndicatorIfPossible())
         .accessibilityLabel("Add Expense")
     }
@@ -197,7 +217,14 @@ struct HomeView: View {
             } label: {
                 Label("Create Budget", systemImage: "plus")
             }
-        } label: { HeaderMenuGlassLabel(systemImage: "ellipsis") }
+        } label: {
+            HeaderMenuGlassLabel(
+                systemImage: "ellipsis",
+                glassNamespace: headerGlassNamespace,
+                glassEffectID: HomeToolbarGlassEffectID.ellipsis,
+                glassEffectUnionID: HomeToolbarGlassEffectID.union
+            )
+        }
         .modifier(HideMenuIndicatorIfPossible())
         .accessibilityLabel("Budget Options")
     }
@@ -216,7 +243,15 @@ struct HomeView: View {
             } label: {
                 Label("Delete Budget", systemImage: "trash")
             }
-        } label: { HeaderMenuGlassLabel(systemImage: "ellipsis", symbolVariants: SymbolVariants.none) }
+        } label: {
+            HeaderMenuGlassLabel(
+                systemImage: "ellipsis",
+                symbolVariants: SymbolVariants.none,
+                glassNamespace: headerGlassNamespace,
+                glassEffectID: HomeToolbarGlassEffectID.ellipsis,
+                glassEffectUnionID: HomeToolbarGlassEffectID.union
+            )
+        }
         .modifier(HideMenuIndicatorIfPossible())
         .accessibilityLabel("Budget Actions")
     }
@@ -822,20 +857,47 @@ private struct HomeHeaderTableTwoColumnRow<Leading: View, Trailing: View>: View 
 }
 
 // MARK: - Header Menu Glass Label (OS26)
+private enum HomeToolbarGlassEffectID {
+    static let ellipsis = "home.toolbar.ellipsis"
+    static let calendar = "home.toolbar.calendar"
+    static let add = "home.toolbar.add"
+    static let union = "home.toolbar.cluster"
+}
+
 private struct HeaderMenuGlassLabel: View {
     @Environment(\.platformCapabilities) private var capabilities
     @EnvironmentObject private var themeManager: ThemeManager
     var systemImage: String
     var symbolVariants: SymbolVariants? = nil
+    var glassNamespace: Namespace.ID? = nil
+    var glassEffectID: String? = nil
+    var glassEffectUnionID: String? = nil
+    var glassTransitionStyle: RootHeaderGlassTransitionStyle = .matchedGeometry
+
+    private var glassConfiguration: RootHeaderGlassEffectConfiguration? {
+        guard let glassNamespace, let glassEffectID else { return nil }
+        return RootHeaderGlassEffectConfiguration(
+            namespace: glassNamespace,
+            id: glassEffectID,
+            unionID: glassEffectUnionID,
+            transition: glassTransitionStyle
+        )
+    }
 
     var body: some View {
         if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-            RootHeaderGlassControl(sizing: .icon) {
+            RootHeaderGlassControl(
+                sizing: .icon,
+                glassEffectConfiguration: glassConfiguration
+            ) {
                 RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)
             }
             .tint(themeManager.selectedTheme.resolvedTint)
         } else {
-            RootHeaderGlassControl(sizing: .icon) {
+            RootHeaderGlassControl(
+                sizing: .icon,
+                glassEffectConfiguration: glassConfiguration
+            ) {
                 RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)
             }
         }


### PR DESCRIPTION
## Summary
- share a namespace for the Home toolbar capsules so the ellipsis, calendar, and add icons reuse a stable glass effect
- add reusable glass effect configuration plumbing to RootHeaderGlassControl so matched-geometry transitions can be applied consistently

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e037b52f40832c96307120f6260c04