### PR TITLE
feat: align home glass transitions

### DIFF
--- a/OffshoreBudgeting/Views/Components/GlassCapsuleContainer.swift
+++ b/OffshoreBudgeting/Views/Components/GlassCapsuleContainer.swift
@@ -11,12 +11,18 @@ struct GlassCapsuleContainer<Content: View>: View {
     private let horizontalPadding: CGFloat
     private let verticalPadding: CGFloat
     private let contentAlignment: Alignment
+    private let namespace: Namespace.ID?
+    private let glassID: String?
+    private let transition: GlassEffectTransition?
 
     init(
         minimumHeight: CGFloat? = nil,
         horizontalPadding: CGFloat = DS.Spacing.l,
         verticalPadding: CGFloat = DS.Spacing.m,
         alignment: Alignment = .leading,
+        namespace: Namespace.ID? = nil,
+        glassID: String? = nil,
+        transition: GlassEffectTransition? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.content = content()
@@ -24,6 +30,9 @@ struct GlassCapsuleContainer<Content: View>: View {
         self.horizontalPadding = horizontalPadding
         self.verticalPadding = verticalPadding
         self.contentAlignment = alignment
+        self.namespace = namespace
+        self.glassID = glassID
+        self.transition = transition
     }
 
     var body: some View {
@@ -40,8 +49,18 @@ struct GlassCapsuleContainer<Content: View>: View {
 
         if #available(iOS 26.0, macCatalyst 26.0, *), capabilities.supportsOS26Translucency {
             GlassEffectContainer {
-                decorated
+                var glassDecorated = decorated
                     .glassEffect(.regular.interactive(), in: capsule)
+
+                if let namespace, let glassID {
+                    glassDecorated = glassDecorated.glassEffectID(glassID, in: namespace)
+                }
+
+                if let transition {
+                    glassDecorated = glassDecorated.glassEffectTransition(transition)
+                }
+
+                glassDecorated
             }
         } else {
             decorated

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -596,6 +596,8 @@ private struct HomeHeaderOverviewTable: View {
     let onAdjustPeriod: (Int) -> Void
     let onAddCategory: () -> Void
 
+    @Namespace private var glassNamespace
+
     var body: some View {
         LazyVStack(alignment: .leading, spacing: HomeHeaderOverviewMetrics.sectionSpacing) {
             titleRow
@@ -681,7 +683,10 @@ private struct HomeHeaderOverviewTable: View {
                 GlassCapsuleContainer(
                     horizontalPadding: DS.Spacing.l,
                     verticalPadding: DS.Spacing.s,
-                    alignment: .center
+                    alignment: .center,
+                    namespace: glassNamespace,
+                    glassID: "home.addCategory",
+                    transition: .materialize
                 ) {
                     Button(action: onAddCategory) {
                         Label("Add Category", systemImage: "plus")
@@ -738,7 +743,10 @@ private struct HomeHeaderOverviewTable: View {
     private var segmentPicker: some View {
         GlassCapsuleContainer(
             horizontalPadding: HomeHeaderOverviewMetrics.controlHorizontalPadding,
-            verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding
+            verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding,
+            namespace: glassNamespace,
+            glassID: "home.segmentPicker",
+            transition: .matchedGeometry
         ) {
             Picker("", selection: $selectedSegment) {
                 Text("Planned Expenses").segmentedFill().tag(BudgetDetailsViewModel.Segment.planned)
@@ -754,7 +762,10 @@ private struct HomeHeaderOverviewTable: View {
         GlassCapsuleContainer(
             horizontalPadding: HomeHeaderOverviewMetrics.controlHorizontalPadding,
             verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding,
-            alignment: .center
+            alignment: .center,
+            namespace: glassNamespace,
+            glassID: "home.sortPicker",
+            transition: .matchedGeometry
         ) {
             Picker("Sort", selection: $sort) {
                 Text("A–Z").segmentedFill().tag(BudgetDetailsViewModel.SortOption.titleAZ)


### PR DESCRIPTION
## Summary
- allow GlassCapsuleContainer to accept optional glass effect metadata for Liquid Glass transitions
- thread the Home header controls through a shared namespace and apply morphing-friendly transitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0500d9e60832c8b34d2e4a1f01567