### PR TITLE
fix: guard glass transition APIs for older OS releases

### DIFF
--- a/OffshoreBudgeting/Views/Components/GlassCapsuleContainer.swift
+++ b/OffshoreBudgeting/Views/Components/GlassCapsuleContainer.swift
@@ -13,7 +13,7 @@ struct GlassCapsuleContainer<Content: View>: View {
     private let contentAlignment: Alignment
     private let namespace: Namespace.ID?
     private let glassID: String?
-    private let transition: GlassEffectTransition?
+    private let transitionStorage: Any?
 
     init(
         minimumHeight: CGFloat? = nil,
@@ -22,7 +22,6 @@ struct GlassCapsuleContainer<Content: View>: View {
         alignment: Alignment = .leading,
         namespace: Namespace.ID? = nil,
         glassID: String? = nil,
-        transition: GlassEffectTransition? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.content = content()
@@ -32,7 +31,28 @@ struct GlassCapsuleContainer<Content: View>: View {
         self.contentAlignment = alignment
         self.namespace = namespace
         self.glassID = glassID
-        self.transition = transition
+        self.transitionStorage = nil
+    }
+
+    @available(iOS 26.0, macCatalyst 26.0, *)
+    init(
+        minimumHeight: CGFloat? = nil,
+        horizontalPadding: CGFloat = DS.Spacing.l,
+        verticalPadding: CGFloat = DS.Spacing.m,
+        alignment: Alignment = .leading,
+        namespace: Namespace.ID? = nil,
+        glassID: String? = nil,
+        transition: GlassEffectTransition,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.content = content()
+        self.minimumHeight = minimumHeight
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
+        self.contentAlignment = alignment
+        self.namespace = namespace
+        self.glassID = glassID
+        self.transitionStorage = transition
     }
 
     var body: some View {
@@ -56,7 +76,7 @@ struct GlassCapsuleContainer<Content: View>: View {
                     glassDecorated = glassDecorated.glassEffectID(glassID, in: namespace)
                 }
 
-                if let transition {
+                if let transition = transitionStorage as? GlassEffectTransition {
                     glassDecorated = glassDecorated.glassEffectTransition(transition)
                 }
 

--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -182,7 +182,7 @@ private extension View {
         capabilities: PlatformCapabilities,
         namespace: Namespace.ID? = nil,
         glassID: String? = nil,
-        transition: GlassEffectTransition? = nil
+        transitionStorage: Any? = nil
     ) -> some View {
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         if capabilities.supportsOS26Translucency {
@@ -190,7 +190,7 @@ private extension View {
                 RootHeaderGlassCapsuleContainer(
                     namespace: namespace,
                     glassID: glassID,
-                    transition: transition
+                    transition: transitionStorage as? GlassEffectTransition
                 ) { self }
             } else {
                 rootHeaderLegacyGlassDecorated(theme: theme, capabilities: capabilities)
@@ -552,7 +552,7 @@ struct RootHeaderGlassControl<Content: View>: View {
     private let background: RootHeaderControlBackground
     private let glassNamespace: Namespace.ID?
     private let glassID: String?
-    private let glassTransition: GlassEffectTransition?
+    private let glassTransitionStorage: Any?
 
     init(
         width: CGFloat? = nil,
@@ -560,7 +560,6 @@ struct RootHeaderGlassControl<Content: View>: View {
         background: RootHeaderControlBackground = .automatic,
         glassNamespace: Namespace.ID? = nil,
         glassID: String? = nil,
-        glassTransition: GlassEffectTransition? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.content = content()
@@ -569,7 +568,26 @@ struct RootHeaderGlassControl<Content: View>: View {
         self.background = background
         self.glassNamespace = glassNamespace
         self.glassID = glassID
-        self.glassTransition = glassTransition
+        self.glassTransitionStorage = nil
+    }
+
+    @available(iOS 26.0, macCatalyst 26.0, *)
+    init(
+        width: CGFloat? = nil,
+        sizing: RootHeaderControlSizing = .automatic,
+        background: RootHeaderControlBackground = .automatic,
+        glassNamespace: Namespace.ID? = nil,
+        glassID: String? = nil,
+        glassTransition: GlassEffectTransition,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.content = content()
+        self.width = width
+        self.sizing = sizing
+        self.background = background
+        self.glassNamespace = glassNamespace
+        self.glassID = glassID
+        self.glassTransitionStorage = glassTransition
     }
 
     @ViewBuilder
@@ -597,7 +615,7 @@ struct RootHeaderGlassControl<Content: View>: View {
                         RootHeaderGlassCapsuleContainer(
                             namespace: glassNamespace,
                             glassID: glassID,
-                            transition: glassTransition
+                            transition: glassTransitionStorage as? GlassEffectTransition
                         ) {
                             content
                                 .frame(width: max(iconSide, d), height: max(iconSide, d))
@@ -631,7 +649,7 @@ struct RootHeaderGlassControl<Content: View>: View {
                     capabilities: capabilities,
                     namespace: glassNamespace,
                     glassID: glassID,
-                    transition: glassTransition
+                    transitionStorage: glassTransitionStorage
                 )
         }
     }

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -156,9 +156,9 @@ struct HomeView: View {
     }
 
     // MARK: Toolbar Actions
-    private var toolbarGlassTransition: GlassEffectTransition? {
+    private var toolbarGlassTransition: Any? {
         if #available(iOS 26.0, macCatalyst 26.0, *) {
-            return .matchedGeometry
+            return GlassEffectTransition.matchedGeometry
         } else {
             return nil
         }
@@ -174,7 +174,7 @@ struct HomeView: View {
                 systemImage: "calendar",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.calendar,
-                transition: toolbarGlassTransition
+                transitionStorage: toolbarGlassTransition
             )
                 .accessibilityLabel(budgetPeriod.displayName)
         }
@@ -191,7 +191,7 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
-                transition: toolbarGlassTransition
+                transitionStorage: toolbarGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -211,7 +211,7 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
-                transition: toolbarGlassTransition
+                transitionStorage: toolbarGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -230,7 +230,7 @@ struct HomeView: View {
                 systemImage: "ellipsis",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.options,
-                transition: toolbarGlassTransition
+                transitionStorage: toolbarGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -257,7 +257,7 @@ struct HomeView: View {
                 symbolVariants: SymbolVariants.none,
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.options,
-                transition: toolbarGlassTransition
+                transitionStorage: toolbarGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -723,14 +723,8 @@ private struct HomeHeaderOverviewTable: View {
         Group {
             if categorySpending.isEmpty {
                 // Full-width, pressable capsule to prompt adding a category
-                GlassCapsuleContainer(
-                    horizontalPadding: DS.Spacing.l,
-                    verticalPadding: DS.Spacing.s,
-                    alignment: .center,
-                    namespace: glassNamespace,
-                    glassID: "home.addCategory",
-                    transition: .materialize
-                ) {
+                @ViewBuilder
+                func addCategoryContent() -> some View {
                     Button(action: onAddCategory) {
                         Label("Add Category", systemImage: "plus")
                             .font(.system(size: 16, weight: .semibold, design: .rounded))
@@ -741,6 +735,31 @@ private struct HomeHeaderOverviewTable: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("home_add_category_cta")
+                }
+
+                Group {
+                    if #available(iOS 26.0, macCatalyst 26.0, *) {
+                        GlassCapsuleContainer(
+                            horizontalPadding: DS.Spacing.l,
+                            verticalPadding: DS.Spacing.s,
+                            alignment: .center,
+                            namespace: glassNamespace,
+                            glassID: "home.addCategory",
+                            transition: .materialize
+                        ) {
+                            addCategoryContent()
+                        }
+                    } else {
+                        GlassCapsuleContainer(
+                            horizontalPadding: DS.Spacing.l,
+                            verticalPadding: DS.Spacing.s,
+                            alignment: .center,
+                            namespace: glassNamespace,
+                            glassID: "home.addCategory"
+                        ) {
+                            addCategoryContent()
+                        }
+                    }
                 }
                 .frame(height: HomeHeaderOverviewMetrics.categoryControlHeight)
             } else {
@@ -784,13 +803,8 @@ private struct HomeHeaderOverviewTable: View {
     }
 
     private var segmentPicker: some View {
-        GlassCapsuleContainer(
-            horizontalPadding: HomeHeaderOverviewMetrics.controlHorizontalPadding,
-            verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding,
-            namespace: glassNamespace,
-            glassID: "home.segmentPicker",
-            transition: .matchedGeometry
-        ) {
+        @ViewBuilder
+        func segmentPickerContent() -> some View {
             Picker("", selection: $selectedSegment) {
                 Text("Planned Expenses").segmentedFill().tag(BudgetDetailsViewModel.Segment.planned)
                 Text("Variable Expenses").segmentedFill().tag(BudgetDetailsViewModel.Segment.variable)
@@ -799,17 +813,34 @@ private struct HomeHeaderOverviewTable: View {
             .equalWidthSegments()
             .frame(maxWidth: .infinity)
         }
+
+        return Group {
+            if #available(iOS 26.0, macCatalyst 26.0, *) {
+                GlassCapsuleContainer(
+                    horizontalPadding: HomeHeaderOverviewMetrics.controlHorizontalPadding,
+                    verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding,
+                    namespace: glassNamespace,
+                    glassID: "home.segmentPicker",
+                    transition: .matchedGeometry
+                ) {
+                    segmentPickerContent()
+                }
+            } else {
+                GlassCapsuleContainer(
+                    horizontalPadding: HomeHeaderOverviewMetrics.controlHorizontalPadding,
+                    verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding,
+                    namespace: glassNamespace,
+                    glassID: "home.segmentPicker"
+                ) {
+                    segmentPickerContent()
+                }
+            }
+        }
     }
 
     private var sortPicker: some View {
-        GlassCapsuleContainer(
-            horizontalPadding: HomeHeaderOverviewMetrics.controlHorizontalPadding,
-            verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding,
-            alignment: .center,
-            namespace: glassNamespace,
-            glassID: "home.sortPicker",
-            transition: .matchedGeometry
-        ) {
+        @ViewBuilder
+        func sortPickerContent() -> some View {
             Picker("Sort", selection: $sort) {
                 Text("A–Z").segmentedFill().tag(BudgetDetailsViewModel.SortOption.titleAZ)
                 Text("$↓").segmentedFill().tag(BudgetDetailsViewModel.SortOption.amountLowHigh)
@@ -820,6 +851,31 @@ private struct HomeHeaderOverviewTable: View {
             .pickerStyle(.segmented)
             .equalWidthSegments()
             .frame(maxWidth: .infinity)
+        }
+
+        return Group {
+            if #available(iOS 26.0, macCatalyst 26.0, *) {
+                GlassCapsuleContainer(
+                    horizontalPadding: HomeHeaderOverviewMetrics.controlHorizontalPadding,
+                    verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding,
+                    alignment: .center,
+                    namespace: glassNamespace,
+                    glassID: "home.sortPicker",
+                    transition: .matchedGeometry
+                ) {
+                    sortPickerContent()
+                }
+            } else {
+                GlassCapsuleContainer(
+                    horizontalPadding: HomeHeaderOverviewMetrics.controlHorizontalPadding,
+                    verticalPadding: HomeHeaderOverviewMetrics.controlVerticalPadding,
+                    alignment: .center,
+                    namespace: glassNamespace,
+                    glassID: "home.sortPicker"
+                ) {
+                    sortPickerContent()
+                }
+            }
         }
     }
 
@@ -883,21 +939,38 @@ private struct HeaderMenuGlassLabel: View {
     var symbolVariants: SymbolVariants? = nil
     var glassNamespace: Namespace.ID? = nil
     var glassID: String? = nil
-    var transition: GlassEffectTransition? = nil
+    var transitionStorage: Any? = nil
 
     var body: some View {
-        RootHeaderGlassControl(
-            sizing: .icon,
-            background: .clear,
-            glassNamespace: glassNamespace,
-            glassID: glassID,
-            glassTransition: transition
-        ) {
+        @ViewBuilder
+        func iconContent() -> some View {
             RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)
                 .frame(
                     width: RootHeaderActionMetrics.minimumIconDimension,
                     height: RootHeaderActionMetrics.minimumIconDimension
                 )
+        }
+
+        if #available(iOS 26.0, macCatalyst 26.0, *),
+           let transition = transitionStorage as? GlassEffectTransition {
+            RootHeaderGlassControl(
+                sizing: .icon,
+                background: .clear,
+                glassNamespace: glassNamespace,
+                glassID: glassID,
+                glassTransition: transition
+            ) {
+                iconContent()
+            }
+        } else {
+            RootHeaderGlassControl(
+                sizing: .icon,
+                background: .clear,
+                glassNamespace: glassNamespace,
+                glassID: glassID
+            ) {
+                iconContent()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace stored GlassEffectTransition properties with availability-neutral storage and add OS 26-only initializers
- cast the backing storage when applying glass transitions in RootHeader glass helpers
- gate Home view capsules and toolbar items behind availability checks before requesting transitions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0563bbc64832ca62dbda7d31c2fb1