### PR TITLE
fix: compose root header glass capsule without mutation

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -158,18 +158,27 @@ private struct RootHeaderGlassCapsuleContainer<Content: View>: View {
 
     var body: some View {
         GlassEffectContainer {
-            var decorated = content
-                .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
+            decoratedContent(
+                content.glassEffect(
+                    .regular.interactive(),
+                    in: Capsule(style: .continuous)
+                )
+            )
+        }
+    }
 
-            if let namespace, let glassID {
-                decorated = decorated.glassEffectID(glassID, in: namespace)
-            }
-
-            if let transition {
-                decorated = decorated.glassEffectTransition(transition)
-            }
-
-            decorated
+    @ViewBuilder
+    private func decoratedContent<V: View>(_ view: V) -> some View {
+        if let namespace, let glassID, let transition {
+            view
+                .glassEffectID(glassID, in: namespace)
+                .glassEffectTransition(transition)
+        } else if let namespace, let glassID {
+            view.glassEffectID(glassID, in: namespace)
+        } else if let transition {
+            view.glassEffectTransition(transition)
+        } else {
+            view
         }
     }
 }


### PR DESCRIPTION
## Summary
- update RootHeaderGlassCapsuleContainer to decorate the content view without mutable temporaries
- add a helper view-builder that conditionally applies glassEffectID and glassEffectTransition so the container returns a single composed view

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e05ab9de9c832cad307f618d8795b1