### PR TITLE
fix: lift add category content helper

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -722,21 +722,6 @@ private struct HomeHeaderOverviewTable: View {
     private var categoryRow: some View {
         Group {
             if categorySpending.isEmpty {
-                // Full-width, pressable capsule to prompt adding a category
-                @ViewBuilder
-                func addCategoryContent() -> some View {
-                    Button(action: onAddCategory) {
-                        Label("Add Category", systemImage: "plus")
-                            .font(.system(size: 16, weight: .semibold, design: .rounded))
-                            .frame(
-                                maxWidth: .infinity,
-                                minHeight: HomeHeaderOverviewMetrics.categoryControlHeight
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("home_add_category_cta")
-                }
-
                 Group {
                     if #available(iOS 26.0, macCatalyst 26.0, *) {
                         GlassCapsuleContainer(
@@ -772,6 +757,20 @@ private struct HomeHeaderOverviewTable: View {
             }
         }
         .padding(.top, HomeHeaderOverviewMetrics.categoryChipTopSpacing)
+    }
+
+    @ViewBuilder
+    private func addCategoryContent() -> some View {
+        Button(action: onAddCategory) {
+            Label("Add Category", systemImage: "plus")
+                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: HomeHeaderOverviewMetrics.categoryControlHeight
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("home_add_category_cta")
     }
 
     private var totalLabelView: some View {


### PR DESCRIPTION
## Summary
- extract the add category button content into a dedicated helper in HomeView
- reuse the helper in both GlassCapsuleContainer branches while keeping the iOS 26+ transition behavior intact

## Testing
- Not run (Xcode not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e05d4beff8832cb1db48c4e3a3230c