### PR TITLE
fix(view): extract home header icon helper

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -940,16 +940,16 @@ private struct HeaderMenuGlassLabel: View {
     var glassID: String? = nil
     var transitionStorage: Any? = nil
 
-    var body: some View {
-        @ViewBuilder
-        func iconContent() -> some View {
-            RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)
-                .frame(
-                    width: RootHeaderActionMetrics.minimumIconDimension,
-                    height: RootHeaderActionMetrics.minimumIconDimension
-                )
-        }
+    @ViewBuilder
+    private func iconContent() -> some View {
+        RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)
+            .frame(
+                width: RootHeaderActionMetrics.minimumIconDimension,
+                height: RootHeaderActionMetrics.minimumIconDimension
+            )
+    }
 
+    var body: some View {
         if #available(iOS 26.0, macCatalyst 26.0, *),
            let transition = transitionStorage as? GlassEffectTransition {
             RootHeaderGlassControl(


### PR DESCRIPTION
## Summary
- move the header menu icon layout into a reusable helper so both glass-control branches share it

## Testing
- not run (xcodebuild unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e05e1a7834832c9a1d96d0b6b37ba6