### PR TITLE
Fix period navigation animation for glass effect

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -45,6 +45,9 @@ struct HomeView: View {
 
     // MARK: Body
     @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.platformCapabilities) private var capabilities
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         // Sticky header is managed by RootTabPageScaffold.
         // - Empty states leverage the scaffold's scroll view for reachability.
@@ -148,7 +151,7 @@ struct HomeView: View {
             selectedSegment: $selectedSegment,
             sort: $homeSort,
             periodNavigationTitle: title(for: vm.selectedDate),
-            onAdjustPeriod: { delta in vm.adjustSelectedPeriod(by: delta) },
+            onAdjustPeriod: { delta in performPeriodAdjustment(by: delta) },
             onAddCategory: { isPresentingManageCategories = true },
             topPaddingStyle: topPaddingStyle,
             content: content
@@ -436,6 +439,21 @@ struct HomeView: View {
     // MARK: Helpers
     private func title(for date: Date) -> String {
         budgetPeriod.title(for: date)
+    }
+
+    private var periodAdjustmentAnimation: Animation {
+        .spring(response: 0.32, dampingFraction: 0.72, blendDuration: 0.15)
+    }
+
+    private func performPeriodAdjustment(by delta: Int) {
+        guard capabilities.supportsOS26Translucency, !reduceMotion else {
+            vm.adjustSelectedPeriod(by: delta)
+            return
+        }
+
+        withAnimation(periodAdjustmentAnimation) {
+            vm.adjustSelectedPeriod(by: delta)
+        }
     }
 
     // Period-driven header title, e.g. "September 2025 Budget" or


### PR DESCRIPTION
## Summary
- gate HomeView period adjustments on OS 26 support and reduce-motion settings
- wrap period navigation updates in a spring animation so the glass capsule transition runs smoothly

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e06328fa20832c8d1de89a468522f9