### PR TITLE
Adjust toolbar glass transitions for OS26 materialization

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -160,8 +160,12 @@ struct HomeView: View {
 
     // MARK: Toolbar Actions
     private var toolbarGlassTransition: GlassEffectTransition? {
+        guard capabilities.supportsOS26Translucency else {
+            return nil
+        }
+
         if #available(iOS 26.0, macCatalyst 26.0, *) {
-            return .matchedGeometry
+            return reduceMotion ? .identity : .materialize
         } else {
             return nil
         }


### PR DESCRIPTION
## Summary
- update the Home toolbar glass transition to use Liquid Glass materialize effects on modern platforms
- honor reduced motion preferences by falling back to the identity transition while keeping legacy platforms unchanged

## Testing
- not run (iOS manual test required)

------
https://chatgpt.com/codex/tasks/task_e_68e06476e928832cabc38a0e680731e9