### PR TITLE
Restore calendar menu with selectable budget periods

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -205,7 +205,16 @@ struct HomeView: View {
     private func calendarToolbarMenu() -> some View {
         Menu {
             ForEach(BudgetPeriod.selectableCases) { period in
-                Button(period.displayName) { budgetPeriodRawValue = period.rawValue }
+                Button {
+                    budgetPeriodRawValue = period.rawValue
+                } label: {
+                    Label {
+                        Text(period.displayName)
+                    } icon: {
+                        Image(systemName: "checkmark")
+                            .opacity(budgetPeriod == period ? 1 : 0)
+                    }
+                }
             }
         } label: {
             HeaderMenuGlassLabel(


### PR DESCRIPTION
## Summary
- restore the calendar toolbar menu to iterate `BudgetPeriod.selectableCases` and update the stored period when tapped
- keep the shared glass label wrapper while highlighting the active period with a checkmark

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e08e2c373c832caac9c1ca69a727ea