### PR TITLE
Refine calendar toolbar menu styling

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -819,3 +819,29 @@ struct RootHeaderIconActionButton: View {
         }
     }
 }
+
+struct RootHeaderMenuButtonLabel: View {
+    @Environment(\.platformCapabilities) private var capabilities
+    var systemImage: String
+    var symbolVariants: SymbolVariants? = nil
+    var glassNamespace: Namespace.ID? = nil
+    var glassID: String? = nil
+    var glassUnionID: String? = nil
+    var glassTransition: Any? = nil
+
+    var body: some View {
+        RootHeaderGlassControl(
+            sizing: .icon,
+            glassNamespace: glassNamespace,
+            glassID: glassID,
+            glassUnionID: glassUnionID,
+            glassTransition: glassTransition
+        ) {
+            RootHeaderControlIcon(systemImage: systemImage, symbolVariants: symbolVariants)
+                .frame(
+                    width: RootHeaderActionMetrics.iconDimension(for: capabilities, width: nil),
+                    height: RootHeaderActionMetrics.iconDimension(for: capabilities, width: nil)
+                )
+        }
+    }
+}

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -202,8 +202,9 @@ struct HomeView: View {
         .spring(response: 0.34, dampingFraction: 0.78, blendDuration: 0.1)
     }
 
+    @ViewBuilder
     private func calendarToolbarMenu() -> some View {
-        Menu {
+        let menu = Menu {
             ForEach(BudgetPeriod.selectableCases) { period in
                 Button {
                     budgetPeriodRawValue = period.rawValue
@@ -211,22 +212,46 @@ struct HomeView: View {
                     Label {
                         Text(period.displayName)
                     } icon: {
-                        Image(systemName: "checkmark")
-                            .opacity(budgetPeriod == period ? 1 : 0)
+                        if budgetPeriod == period {
+                            Image(systemName: "checkmark")
+                        } else {
+                            Image(systemName: "checkmark")
+                                .hidden()
+                                .accessibilityHidden(true)
+                        }
                     }
                 }
             }
         } label: {
-            HeaderMenuGlassLabel(
-                systemImage: "calendar",
-                glassNamespace: toolbarGlassNamespace,
-                glassID: HomeToolbarGlassIdentifiers.calendar,
-                transition: toolbarGlassTransition
-            )
+            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
+                RootHeaderMenuButtonLabel(
+                    systemImage: "calendar",
+                    glassNamespace: toolbarGlassNamespace,
+                    glassID: HomeToolbarGlassIdentifiers.calendar,
+                    glassTransition: toolbarGlassTransition
+                )
                 .accessibilityLabel(budgetPeriod.displayName)
+            } else {
+                HeaderMenuGlassLabel(
+                    systemImage: "calendar",
+                    glassNamespace: toolbarGlassNamespace,
+                    glassID: HomeToolbarGlassIdentifiers.calendar,
+                    transition: toolbarGlassTransition
+                )
+                .accessibilityLabel(budgetPeriod.displayName)
+            }
         }
         .modifier(HideMenuIndicatorIfPossible())
         .accessibilityLabel(budgetPeriod.displayName)
+
+        if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
+            menu
+                .menuStyle(.button)
+                .buttonBorderShape(.circle)
+                .tint(themeManager.selectedTheme.resolvedTint)
+        } else {
+            menu
+        }
     }
 
     private func addExpenseToolbarMenu() -> some View {


### PR DESCRIPTION
## Summary
- add a reusable RootHeaderMenuButtonLabel that mirrors the glass icon controls for menus
- update HomeView's calendar toolbar menu to adopt the glass-styled button on OS 26 while keeping the legacy presentation intact
- adjust the period selection checkmark so the active period stays visible without relying on opacity

## Testing
- Not run (iOS simulator required)


------
https://chatgpt.com/codex/tasks/task_e_68e092d13f6c832c80c33b4b3e3f382c