### PR TITLE
Fix Home calendar menu glass background

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -828,10 +828,12 @@ struct RootHeaderMenuButtonLabel: View {
     var glassID: String? = nil
     var glassUnionID: String? = nil
     var glassTransition: Any? = nil
+    var background: RootHeaderControlBackground = .automatic
 
     var body: some View {
         RootHeaderGlassControl(
             sizing: .icon,
+            background: background,
             glassNamespace: glassNamespace,
             glassID: glassID,
             glassUnionID: glassUnionID,

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -228,7 +228,8 @@ struct HomeView: View {
                     systemImage: "calendar",
                     glassNamespace: toolbarGlassNamespace,
                     glassID: HomeToolbarGlassIdentifiers.calendar,
-                    glassTransition: toolbarGlassTransition
+                    glassTransition: toolbarGlassTransition,
+                    background: .clear
                 )
                 .accessibilityLabel(budgetPeriod.displayName)
             } else {


### PR DESCRIPTION
## Summary
- allow `RootHeaderMenuButtonLabel` to opt into a clear glass background when needed
- apply the clear background to the Home calendar menu so it matches adjacent toolbar controls

## Testing
- Not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e08fbb9470832caf00e80a6ea1b6ef