### PR TITLE
Disable home category chip interactions

### DIFF
--- a/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
+++ b/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CategoryTotalsRow: View {
     let categories: [BudgetSummary.CategorySpending]
     var isPlaceholder: Bool = false
+    var isInteractive: Bool = true
     var horizontalInset: CGFloat = DS.Spacing.l
     private let controlHeight: CGFloat = 44
     @Environment(\.platformCapabilities) private var capabilities
@@ -45,6 +46,7 @@ struct CategoryTotalsRow: View {
                         }
                         .padding(.horizontal, horizontalInset)
                     }
+                    .allowsHitTesting(isInteractive)
                 }
             } else {
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -69,6 +71,7 @@ struct CategoryTotalsRow: View {
                     }
                     .padding(.horizontal, horizontalInset)
                 }
+                .allowsHitTesting(isInteractive)
             }
         }
         .ub_hideScrollIndicators()

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -812,6 +812,7 @@ private struct HomeHeaderOverviewTable: View {
                 CategoryTotalsRow(
                     categories: categorySpending,
                     isPlaceholder: false,
+                    isInteractive: false,
                     horizontalInset: 0
                 )
                 .frame(height: HomeHeaderOverviewMetrics.categoryControlHeight)
@@ -820,6 +821,7 @@ private struct HomeHeaderOverviewTable: View {
                 CategoryTotalsRow(
                     categories: globalCategorySpending,
                     isPlaceholder: false,
+                    isInteractive: false,
                     horizontalInset: 0
                 )
                 .frame(height: HomeHeaderOverviewMetrics.categoryControlHeight)


### PR DESCRIPTION
## Summary
- add an `isInteractive` flag to `CategoryTotalsRow` so chip rows can ignore touch events
- apply the flag to HomeView so the glass-style category row is non-interactive while keeping existing defaults intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e09a7369d4832ca54549c6ea1be3f1