### PR TITLE
Restore IncomeView bottom padding across layouts

### DIFF
--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -153,6 +153,10 @@ struct IncomeView: View {
         )
     }
 
+    private func contentBottomInset(using proxy: RootTabPageProxy) -> CGFloat {
+        proxy.safeAreaBottomInset + DS.Spacing.s
+    }
+
     private let landscapeLayoutMinimumWidth: CGFloat = 780
     private let landscapeSummarySpansFullWidth: Bool = true
 
@@ -317,6 +321,7 @@ struct IncomeView: View {
             proxy,
             horizontal: horizontalInset,
             extraTop: DS.Spacing.s,
+            extraBottom: contentBottomInset(using: proxy),
             includeSafeArea: false,
             tabBarGutter: gutter
         )
@@ -352,6 +357,7 @@ struct IncomeView: View {
             proxy,
             horizontal: horizontalInset,
             extraTop: DS.Spacing.s,
+            extraBottom: contentBottomInset(using: proxy),
             includeSafeArea: false,
             tabBarGutter: gutter
         )
@@ -379,12 +385,12 @@ struct IncomeView: View {
                 proxy,
                 horizontal: horizontalInset,
                 extraTop: DS.Spacing.s,
+                extraBottom: contentBottomInset(using: proxy),
                 includeSafeArea: false,
                 tabBarGutter: gutter
             )
         }
-        // Removed extra bottom inset; RootTabPageScaffold + rootTabContentPadding
-        // control any desired gutter above the tab bar.
+        // RootTabPageScaffold + rootTabContentPadding control the gutter above the tab bar.
     }
 
     private func adaptiveCardHeights(


### PR DESCRIPTION
## Summary
- add a shared helper to calculate the desired bottom inset for IncomeView content
- apply the inset to the portrait scrolling, portrait fixed, and landscape layouts so the weekly summary card keeps consistent spacing

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e09d0502bc832c93d07966964e8432