### PR TITLE
Enhance category chip selection styling across expense forms

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -505,9 +505,12 @@ private struct CategoryChip: View {
     var body: some View {
         let capsule = Capsule(style: .continuous)
         let tint = themeManager.selectedTheme.resolvedTint
-        let fallbackFill: Color = isSelected ? DS.Colors.chipSelectedFill : DS.Colors.chipFill
-        let fallbackStroke: Color = isSelected ? DS.Colors.chipSelectedStroke : DS.Colors.chipFill
-        let fallbackLineWidth: CGFloat = isSelected ? 1.5 : 1
+        let style = CategoryChipStyle.make(
+            isSelected: isSelected,
+            tint: tint,
+            colorScheme: colorScheme,
+            readability: { readableForegroundColor(for: $0) }
+        )
 
         let content = HStack(spacing: DS.Spacing.s) {
             Circle()
@@ -522,13 +525,17 @@ private struct CategoryChip: View {
 
         Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                let glassTextColor: Color = isSelected ? readableForegroundColor(for: tint) : .primary
                 let glassContent = content
-                    .foregroundStyle(glassTextColor)
+                    .foregroundStyle(style.glassTextColor)
                     .glassEffect(
                         isSelected ? .regular.tint(tint).interactive() : .regular.interactive(),
                         in: capsule
                     )
+                    .overlay {
+                        if let stroke = style.glassStroke {
+                            capsule.stroke(stroke.color, lineWidth: stroke.lineWidth)
+                        }
+                    }
 
                 if let ns = namespace {
                     glassContent
@@ -537,18 +544,27 @@ private struct CategoryChip: View {
                     glassContent
                 }
             } else {
-                let legacyTextColor: Color = isSelected ? readableForegroundColor(for: fallbackFill) : .primary
                 content
-                    .foregroundStyle(legacyTextColor)
-                    .background(capsule.fill(fallbackFill))
+                    .foregroundStyle(style.fallbackTextColor)
+                    .background {
+                        capsule
+                            .fill(DS.Colors.chipFill)
+                            .overlay {
+                                if let overlay = style.fallbackOverlay {
+                                    capsule.fill(overlay)
+                                }
+                            }
+                    }
                     .overlay(
                         capsule.stroke(
-                            fallbackStroke,
-                            lineWidth: fallbackLineWidth
+                            style.fallbackStroke.color,
+                            lineWidth: style.fallbackStroke.lineWidth
                         )
                     )
             }
         }
+        .scaleEffect(style.scale)
+        .shadow(color: style.shadowColor, radius: style.shadowRadius, x: 0, y: style.shadowY)
         .animation(.easeOut(duration: 0.15), value: isSelected)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct CategoryChipStyle {
+    struct Stroke {
+        let color: Color
+        let lineWidth: CGFloat
+    }
+
+    let scale: CGFloat
+    let fallbackTextColor: Color
+    let fallbackOverlay: Color?
+    let fallbackStroke: Stroke
+    let glassTextColor: Color
+    let glassStroke: Stroke?
+    let shadowColor: Color
+    let shadowRadius: CGFloat
+    let shadowY: CGFloat
+
+    static func make(
+        isSelected: Bool,
+        tint: Color,
+        colorScheme: ColorScheme,
+        readability: (Color) -> Color
+    ) -> CategoryChipStyle {
+        if isSelected {
+            let overlayOpacity: Double = colorScheme == .dark ? 0.45 : 0.2
+            let overlayColor = tint.opacity(overlayOpacity)
+            let strokeOpacity: Double = colorScheme == .dark ? 0.9 : 0.65
+            let strokeColor = tint.opacity(strokeOpacity)
+
+            return CategoryChipStyle(
+                scale: 1.04,
+                fallbackTextColor: readability(overlayColor),
+                fallbackOverlay: overlayColor,
+                fallbackStroke: Stroke(color: strokeColor, lineWidth: 2),
+                glassTextColor: readability(tint),
+                glassStroke: Stroke(color: strokeColor, lineWidth: 2),
+                shadowColor: tint.opacity(colorScheme == .dark ? 0.55 : 0.35),
+                shadowRadius: 6,
+                shadowY: 3
+            )
+        } else {
+            return CategoryChipStyle(
+                scale: 1.0,
+                fallbackTextColor: .primary,
+                fallbackOverlay: nil,
+                fallbackStroke: Stroke(color: DS.Colors.chipFill, lineWidth: 1),
+                glassTextColor: .primary,
+                glassStroke: nil,
+                shadowColor: .clear,
+                shadowRadius: 0,
+                shadowY: 0
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract a shared `CategoryChipStyle` helper so planned and unplanned expense forms use identical chip styling
- update the planned and unplanned expense category chips to apply tinted overlays, selection strokes, and motion for both glass and fallback appearances

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e109673be0832c8351802783301a7c