### PR TITLE
Adjust category chip selection styling

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -504,17 +504,16 @@ private struct CategoryChip: View {
 
     var body: some View {
         let capsule = Capsule(style: .continuous)
-        let tint = themeManager.selectedTheme.resolvedTint
+        let categoryColor = Color(hex: colorHex) ?? .secondary
         let style = CategoryChipStyle.make(
             isSelected: isSelected,
-            tint: tint,
-            colorScheme: colorScheme,
-            readability: { readableForegroundColor(for: $0) }
+            categoryColor: categoryColor,
+            colorScheme: colorScheme
         )
 
         let content = HStack(spacing: DS.Spacing.s) {
             Circle()
-                .fill(Color(hex: colorHex) ?? .secondary)
+                .fill(categoryColor)
                 .frame(width: 10, height: 10)
             Text(name)
                 .font(.subheadline.weight(.semibold))
@@ -528,7 +527,7 @@ private struct CategoryChip: View {
                 let glassContent = content
                     .foregroundStyle(style.glassTextColor)
                     .glassEffect(
-                        isSelected ? .regular.tint(tint).interactive() : .regular.interactive(),
+                        .regular.interactive(),
                         in: capsule
                     )
                     .overlay {
@@ -548,12 +547,7 @@ private struct CategoryChip: View {
                     .foregroundStyle(style.fallbackTextColor)
                     .background {
                         capsule
-                            .fill(DS.Colors.chipFill)
-                            .overlay {
-                                if let overlay = style.fallbackOverlay {
-                                    capsule.fill(overlay)
-                                }
-                            }
+                            .fill(style.fallbackFill)
                     }
                     .overlay(
                         capsule.stroke(
@@ -569,39 +563,6 @@ private struct CategoryChip: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    private func readableForegroundColor(for background: Color) -> Color {
-        guard let resolvedColor = resolveUIColor(for: background) else {
-            return .white
-        }
-
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-
-        if resolvedColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
-            let brightness = 0.299 * red + 0.587 * green + 0.114 * blue
-            return brightness < 0.55 ? .white : .black
-        }
-
-        var white: CGFloat = 0
-        if resolvedColor.getWhite(&white, alpha: &alpha) {
-            return white < 0.55 ? .white : .black
-        }
-
-        return .white
-    }
-
-    private func resolveUIColor(for color: Color) -> UIColor? {
-#if canImport(UIKit)
-        let uiColor = UIColor(color)
-        let userInterfaceStyle: UIUserInterfaceStyle = colorScheme == .dark ? .dark : .light
-        let traitCollection = UITraitCollection(userInterfaceStyle: userInterfaceStyle)
-        return uiColor.resolvedColor(with: traitCollection)
-#else
-        return nil
-#endif
-    }
 }
 
 // MARK: - Style Adapters

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -370,17 +370,16 @@ private struct CategoryChip: View {
 
     var body: some View {
         let capsule = Capsule(style: .continuous)
-        let tint = themeManager.selectedTheme.resolvedTint
+        let categoryColor = Color(hex: colorHex) ?? .secondary
         let style = CategoryChipStyle.make(
             isSelected: isSelected,
-            tint: tint,
-            colorScheme: colorScheme,
-            readability: { readableForegroundColor(for: $0) }
+            categoryColor: categoryColor,
+            colorScheme: colorScheme
         )
 
         let content = HStack(spacing: DS.Spacing.s) {
             Circle()
-                .fill(Color(hex: colorHex) ?? .secondary)
+                .fill(categoryColor)
                 .frame(width: 10, height: 10)
             Text(name)
                 .font(.subheadline.weight(.semibold))
@@ -394,7 +393,7 @@ private struct CategoryChip: View {
                 let glassContent = content
                     .foregroundStyle(style.glassTextColor)
                     .glassEffect(
-                        isSelected ? .regular.tint(tint).interactive() : .regular.interactive(),
+                        .regular.interactive(),
                         in: capsule
                     )
                     .overlay {
@@ -414,12 +413,7 @@ private struct CategoryChip: View {
                     .foregroundStyle(style.fallbackTextColor)
                     .background {
                         capsule
-                            .fill(DS.Colors.chipFill)
-                            .overlay {
-                                if let overlay = style.fallbackOverlay {
-                                    capsule.fill(overlay)
-                                }
-                            }
+                            .fill(style.fallbackFill)
                     }
                     .overlay(
                         capsule.stroke(
@@ -435,39 +429,6 @@ private struct CategoryChip: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    private func readableForegroundColor(for background: Color) -> Color {
-        guard let resolvedColor = resolveUIColor(for: background) else {
-            return .white
-        }
-
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-
-        if resolvedColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
-            let brightness = 0.299 * red + 0.587 * green + 0.114 * blue
-            return brightness < 0.55 ? .white : .black
-        }
-
-        var white: CGFloat = 0
-        if resolvedColor.getWhite(&white, alpha: &alpha) {
-            return white < 0.55 ? .white : .black
-        }
-
-        return .white
-    }
-
-    private func resolveUIColor(for color: Color) -> UIColor? {
-#if canImport(UIKit)
-        let uiColor = UIColor(color)
-        let userInterfaceStyle: UIUserInterfaceStyle = colorScheme == .dark ? .dark : .light
-        let traitCollection = UITraitCollection(userInterfaceStyle: userInterfaceStyle)
-        return uiColor.resolvedColor(with: traitCollection)
-#else
-        return nil
-#endif
-    }
 }
 
 // MARK: - Style Adapters (Shared)

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -8,7 +8,7 @@ struct CategoryChipStyle {
 
     let scale: CGFloat
     let fallbackTextColor: Color
-    let fallbackOverlay: Color?
+    let fallbackFill: Color
     let fallbackStroke: Stroke
     let glassTextColor: Color
     let glassStroke: Stroke?
@@ -18,24 +18,20 @@ struct CategoryChipStyle {
 
     static func make(
         isSelected: Bool,
-        tint: Color,
-        colorScheme: ColorScheme,
-        readability: (Color) -> Color
+        categoryColor: Color,
+        colorScheme: ColorScheme
     ) -> CategoryChipStyle {
         if isSelected {
-            let overlayOpacity: Double = colorScheme == .dark ? 0.45 : 0.2
-            let overlayColor = tint.opacity(overlayOpacity)
-            let strokeOpacity: Double = colorScheme == .dark ? 0.9 : 0.65
-            let strokeColor = tint.opacity(strokeOpacity)
+            let strokeColor = categoryColor
 
             return CategoryChipStyle(
                 scale: 1.04,
-                fallbackTextColor: readability(overlayColor),
-                fallbackOverlay: overlayColor,
+                fallbackTextColor: .primary,
+                fallbackFill: .clear,
                 fallbackStroke: Stroke(color: strokeColor, lineWidth: 2),
-                glassTextColor: readability(tint),
+                glassTextColor: .primary,
                 glassStroke: Stroke(color: strokeColor, lineWidth: 2),
-                shadowColor: tint.opacity(colorScheme == .dark ? 0.55 : 0.35),
+                shadowColor: categoryColor.opacity(colorScheme == .dark ? 0.55 : 0.35),
                 shadowRadius: 6,
                 shadowY: 3
             )
@@ -43,7 +39,7 @@ struct CategoryChipStyle {
             return CategoryChipStyle(
                 scale: 1.0,
                 fallbackTextColor: .primary,
-                fallbackOverlay: nil,
+                fallbackFill: DS.Colors.chipFill,
                 fallbackStroke: Stroke(color: DS.Colors.chipFill, lineWidth: 1),
                 glassTextColor: .primary,
                 glassStroke: nil,


### PR DESCRIPTION
## Summary
- update `CategoryChipStyle` to derive selected borders and shadows from the category color while keeping text adaptive to the system theme
- update planned and unplanned expense category chips to pass category colors through the style factory, use the untinted glass effect, and rely on the style-provided stroke/fill handling

## Testing
- not run (simulator not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e10e483668832caf044cfb03a857a0