### PR TITLE
Add leading padding to category chip carousels

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -401,6 +401,7 @@ private struct CategoryChipsRow: View {
                             }
                             .padding(.trailing, DS.Spacing.s)
                         }
+                        .padding(.leading, DS.Spacing.s)
                         .ub_hideScrollIndicators()
                     }
                 } else {
@@ -425,6 +426,7 @@ private struct CategoryChipsRow: View {
                         }
                         .padding(.trailing, DS.Spacing.s)
                     }
+                    .padding(.leading, DS.Spacing.s)
                     .ub_hideScrollIndicators()
                 }
             }

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -264,6 +264,7 @@ private struct CategoryChipsRow: View {
                             }
                             .padding(.trailing, DS.Spacing.s)
                         }
+                        .padding(.leading, DS.Spacing.s)
                     }
                 } else {
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -287,6 +288,7 @@ private struct CategoryChipsRow: View {
                         }
                         .padding(.trailing, DS.Spacing.s)
                     }
+                    .padding(.leading, DS.Spacing.s)
                 }
             }
             // Hide scroll indicators consistently across platforms


### PR DESCRIPTION
## Summary
- add leading inset to the category chip scroll views in the planned and unplanned expense forms so the first chip has breathing room

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1132fd860832c8959ea9a9b4801d5