### PR TITLE
Fix category chip scroll padding

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -404,9 +404,8 @@ private struct CategoryChipsRow: View {
                                     }
                                 }
                             }
-                            .padding(.trailing, DS.Spacing.s)
+                            .padding(.horizontal, DS.Spacing.s)
                         }
-                        .padding(.leading, DS.Spacing.s)
                         .ub_hideScrollIndicators()
                     }
                 } else {
@@ -429,9 +428,8 @@ private struct CategoryChipsRow: View {
                                 }
                             }
                         }
-                        .padding(.trailing, DS.Spacing.s)
+                        .padding(.horizontal, DS.Spacing.s)
                     }
-                    .padding(.leading, DS.Spacing.s)
                     .ub_hideScrollIndicators()
                 }
             }

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -267,9 +267,8 @@ private struct CategoryChipsRow: View {
                                     }
                                 }
                             }
-                            .padding(.trailing, DS.Spacing.s)
+                            .padding(.horizontal, DS.Spacing.s)
                         }
-                        .padding(.leading, DS.Spacing.s)
                     }
                 } else {
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -291,9 +290,8 @@ private struct CategoryChipsRow: View {
                                 }
                             }
                         }
-                        .padding(.trailing, DS.Spacing.s)
+                        .padding(.horizontal, DS.Spacing.s)
                     }
-                    .padding(.leading, DS.Spacing.s)
                 }
             }
             // Hide scroll indicators consistently across platforms


### PR DESCRIPTION
## Summary
- shift the category chip inset onto the LazyHStack in AddPlannedExpenseView so the scroll view remains flush while the chips keep balanced spacing
- mirror the LazyHStack inset change in AddUnplannedExpenseView for consistent chip presentation

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e118147f4c832cac14933322d1a7b2