### PR TITLE
fix: inset category chip borders

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -546,7 +546,7 @@ private struct CategoryChip: View {
                     )
                     .overlay {
                         if let stroke = style.glassStroke {
-                            capsule.stroke(stroke.color, lineWidth: stroke.lineWidth)
+                            capsule.strokeBorder(stroke.color, lineWidth: stroke.lineWidth)
                         }
                     }
 
@@ -563,12 +563,12 @@ private struct CategoryChip: View {
                         capsule
                             .fill(style.fallbackFill)
                     }
-                    .overlay(
-                        capsule.stroke(
+                    .overlay {
+                        capsule.strokeBorder(
                             style.fallbackStroke.color,
                             lineWidth: style.fallbackStroke.lineWidth
                         )
-                    )
+                    }
             }
         }
         .scaleEffect(style.scale)

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -412,7 +412,7 @@ private struct CategoryChip: View {
                     )
                     .overlay {
                         if let stroke = style.glassStroke {
-                            capsule.stroke(stroke.color, lineWidth: stroke.lineWidth)
+                            capsule.strokeBorder(stroke.color, lineWidth: stroke.lineWidth)
                         }
                     }
 
@@ -429,12 +429,12 @@ private struct CategoryChip: View {
                         capsule
                             .fill(style.fallbackFill)
                     }
-                    .overlay(
-                        capsule.stroke(
+                    .overlay {
+                        capsule.strokeBorder(
                             style.fallbackStroke.color,
                             lineWidth: style.fallbackStroke.lineWidth
                         )
-                    )
+                    }
             }
         }
         .scaleEffect(style.scale)


### PR DESCRIPTION
## Summary
- update CategoryChip overlays in planned and unplanned expense forms to rely on strokeBorder so the 2 pt outline renders inside the capsule mask
- keep glass and fallback appearances visually consistent when the chip is selected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e128df9b24832c87cb5bd735097ba2