### PR TITLE
Remove shadows from category chips

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -375,7 +375,6 @@ private struct CategoryChipsRow: View {
     @Binding var selectedCategoryID: NSManagedObjectID?
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.platformCapabilities) private var capabilities
-    @EnvironmentObject private var themeManager: ThemeManager
     @Namespace private var glassNamespace
 
     @FetchRequest(
@@ -514,16 +513,13 @@ private struct CategoryChip: View {
     let isSelected: Bool
     let namespace: Namespace.ID?
     @Environment(\.platformCapabilities) private var capabilities
-    @EnvironmentObject private var themeManager: ThemeManager
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         let capsule = CategoryPillMetrics.shape
         let categoryColor = Color(hex: colorHex) ?? .secondary
         let style = CategoryChipStyle.make(
             isSelected: isSelected,
-            categoryColor: categoryColor,
-            colorScheme: colorScheme
+            categoryColor: categoryColor
         )
 
         let content = CategoryPillMetrics.layout {
@@ -572,7 +568,6 @@ private struct CategoryChip: View {
             }
         }
         .scaleEffect(style.scale)
-        .shadow(color: style.shadowColor, radius: style.shadowRadius, x: 0, y: style.shadowY)
         .animation(.easeOut(duration: 0.15), value: isSelected)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -242,7 +242,6 @@ private struct CategoryChipsRow: View {
     // MARK: Local State
     @State private var isPresentingNewCategory = false
     @Environment(\.platformCapabilities) private var capabilities
-    @EnvironmentObject private var themeManager: ThemeManager
     @Namespace private var glassNamespace
 
     var body: some View {
@@ -380,16 +379,13 @@ private struct CategoryChip: View {
     let isSelected: Bool
     let namespace: Namespace.ID?
     @Environment(\.platformCapabilities) private var capabilities
-    @EnvironmentObject private var themeManager: ThemeManager
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         let capsule = CategoryPillMetrics.shape
         let categoryColor = Color(hex: colorHex) ?? .secondary
         let style = CategoryChipStyle.make(
             isSelected: isSelected,
-            categoryColor: categoryColor,
-            colorScheme: colorScheme
+            categoryColor: categoryColor
         )
 
         let content = CategoryPillMetrics.layout {
@@ -438,7 +434,6 @@ private struct CategoryChip: View {
             }
         }
         .scaleEffect(style.scale)
-        .shadow(color: style.shadowColor, radius: style.shadowRadius, x: 0, y: style.shadowY)
         .animation(.easeOut(duration: 0.15), value: isSelected)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -12,14 +12,9 @@ struct CategoryChipStyle {
     let fallbackStroke: Stroke
     let glassTextColor: Color
     let glassStroke: Stroke?
-    let shadowColor: Color
-    let shadowRadius: CGFloat
-    let shadowY: CGFloat
-
     static func make(
         isSelected: Bool,
-        categoryColor: Color,
-        colorScheme: ColorScheme
+        categoryColor: Color
     ) -> CategoryChipStyle {
         if isSelected {
             let strokeColor = categoryColor
@@ -30,10 +25,7 @@ struct CategoryChipStyle {
                 fallbackFill: .clear,
                 fallbackStroke: Stroke(color: strokeColor, lineWidth: 2),
                 glassTextColor: .primary,
-                glassStroke: Stroke(color: strokeColor, lineWidth: 2),
-                shadowColor: categoryColor.opacity(colorScheme == .dark ? 0.55 : 0.35),
-                shadowRadius: 6,
-                shadowY: 3
+                glassStroke: Stroke(color: strokeColor, lineWidth: 2)
             )
         } else {
             return CategoryChipStyle(
@@ -42,10 +34,7 @@ struct CategoryChipStyle {
                 fallbackFill: DS.Colors.chipFill,
                 fallbackStroke: Stroke(color: DS.Colors.chipFill, lineWidth: 1),
                 glassTextColor: .primary,
-                glassStroke: nil,
-                shadowColor: .clear,
-                shadowRadius: 0,
-                shadowY: 0
+                glassStroke: nil
             )
         }
     }


### PR DESCRIPTION
## Summary
- stop exposing shadow metrics in `CategoryChipStyle`
- remove shadow modifiers from add-expense category chips so they render flush in light and dark appearances

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e12cce88e0832c855d1212f489347b