### PR TITLE
Fix category chip selection halo

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -536,7 +536,9 @@ private struct CategoryChip: View {
             }
         }
 
-        Group {
+        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
+
+        let chipContent = Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
                 let glassContent = content
                     .foregroundStyle(style.glassTextColor)
@@ -571,10 +573,23 @@ private struct CategoryChip: View {
                     )
             }
         }
-        .scaleEffect(style.scale)
-        .shadow(color: style.shadowColor, radius: style.shadowRadius, x: 0, y: style.shadowY)
-        .animation(.easeOut(duration: 0.15), value: isSelected)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+        let base = chipContent
+            .scaleEffect(style.scale)
+            .animation(.easeOut(duration: 0.15), value: isSelected)
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+        if shouldApplyShadow {
+            base
+                .shadow(
+                    color: style.shadowColor,
+                    radius: style.shadowRadius,
+                    x: 0,
+                    y: style.shadowY
+                )
+        } else {
+            base
+        }
     }
 
 }

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -402,7 +402,9 @@ private struct CategoryChip: View {
             }
         }
 
-        Group {
+        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
+
+        let chipContent = Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
                 let glassContent = content
                     .foregroundStyle(style.glassTextColor)
@@ -437,10 +439,23 @@ private struct CategoryChip: View {
                     )
             }
         }
-        .scaleEffect(style.scale)
-        .shadow(color: style.shadowColor, radius: style.shadowRadius, x: 0, y: style.shadowY)
-        .animation(.easeOut(duration: 0.15), value: isSelected)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+        let base = chipContent
+            .scaleEffect(style.scale)
+            .animation(.easeOut(duration: 0.15), value: isSelected)
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+        if shouldApplyShadow {
+            base
+                .shadow(
+                    color: style.shadowColor,
+                    radius: style.shadowRadius,
+                    x: 0,
+                    y: style.shadowY
+                )
+        } else {
+            base
+        }
     }
 
 }

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -25,15 +25,15 @@ struct CategoryChipStyle {
             let strokeColor = categoryColor
 
             return CategoryChipStyle(
-                scale: 1.04,
+                scale: 1.0,
                 fallbackTextColor: .primary,
                 fallbackFill: .clear,
                 fallbackStroke: Stroke(color: strokeColor, lineWidth: 2),
                 glassTextColor: .primary,
                 glassStroke: Stroke(color: strokeColor, lineWidth: 2),
-                shadowColor: categoryColor.opacity(colorScheme == .dark ? 0.55 : 0.35),
-                shadowRadius: 6,
-                shadowY: 3
+                shadowColor: .clear,
+                shadowRadius: 0,
+                shadowY: 0
             )
         } else {
             return CategoryChipStyle(


### PR DESCRIPTION
## Summary
- keep selected category chips at 1x scale and remove their selection halo
- gate the category chip shadow so add expense forms only render it when requested

## Testing
- not run (UI verification requires simulator)


------
https://chatgpt.com/codex/tasks/task_e_68e1330b85e8832cab1986eb6b217ead