### PR TITLE
Align category chip pill styling across views

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -354,21 +354,6 @@ struct AddPlannedExpenseView: View {
 }
 
 // MARK: - CategoryChipsRow
-/// Shared layout metrics for the category pill controls.
-private enum CategoryPillMetrics {
-    static let controlHeight: CGFloat = 44
-
-    static var shape: Capsule { Capsule(style: .continuous) }
-
-    static func layout<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        content()
-            .padding(.horizontal, DS.Spacing.m)
-            .padding(.vertical, 8)
-            .frame(height: controlHeight, alignment: .center)
-            .contentShape(shape)
-    }
-}
-
 /// Reusable horizontally scrolling row of category chips with an Add button.
 private struct CategoryChipsRow: View {
 
@@ -401,16 +386,14 @@ private struct CategoryChipsRow: View {
                                         .padding(.vertical, 10)
                                 } else {
                                     ForEach(categories, id: \.objectID) { cat in
-                                        let isSel = selectedCategoryID == cat.objectID
                                         CategoryChip(
                                             id: cat.objectID.uriRepresentation().absoluteString,
                                             name: cat.name ?? "Untitled",
                                             colorHex: cat.color ?? "#999999",
-                                            isSelected: isSel,
+                                            isSelected: selectedCategoryID == cat.objectID,
                                             namespace: glassNamespace
                                         )
                                         .onTapGesture { selectedCategoryID = cat.objectID }
-                                        .glassEffectTransition(.matchedGeometry)
                                     }
                                 }
                             }
@@ -487,7 +470,6 @@ private struct PresentationDetentsCompat: ViewModifier {
 // MARK: - AddCategoryPill
 private struct AddCategoryPill: View {
     var onTap: () -> Void
-    @Environment(\.platformCapabilities) private var capabilities
     @EnvironmentObject private var themeManager: ThemeManager
 
     var body: some View {
@@ -497,7 +479,6 @@ private struct AddCategoryPill: View {
         }
         .buttonStyle(
             AddCategoryPillStyle(
-                capabilities: capabilities,
                 tint: themeManager.selectedTheme.resolvedTint
             )
         )
@@ -518,7 +499,6 @@ private struct CategoryChip: View {
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
-        let capsule = CategoryPillMetrics.shape
         let categoryColor = Color(hex: colorHex) ?? .secondary
         let style = CategoryChipStyle.make(
             isSelected: isSelected,
@@ -526,7 +506,17 @@ private struct CategoryChip: View {
             colorScheme: colorScheme
         )
 
-        let content = CategoryPillMetrics.layout {
+        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
+
+        let pill = CategoryChipPill(
+            isSelected: isSelected,
+            selectionColor: categoryColor,
+            glassForeground: style.glassTextColor,
+            fallbackForeground: style.fallbackTextColor,
+            fallbackFill: style.fallbackFill,
+            fallbackStroke: (!isSelected && style.fallbackStroke.lineWidth > 0) ? style.fallbackStroke : nil,
+            glassStroke: isSelected ? nil : style.glassStroke
+        ) {
             HStack(spacing: DS.Spacing.s) {
                 Circle()
                     .fill(categoryColor)
@@ -536,45 +526,18 @@ private struct CategoryChip: View {
             }
         }
 
-        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
-
-        let chipContent = Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                let glassContent = content
-                    .foregroundStyle(style.glassTextColor)
-                    .glassEffect(
-                        .regular.interactive(),
-                        in: capsule
-                    )
-                    .overlay {
-                        if let stroke = style.glassStroke {
-                            capsule.stroke(stroke.color, lineWidth: stroke.lineWidth)
-                        }
-                    }
-
-                if let ns = namespace {
-                    glassContent
-                        .glassEffectID(id, in: ns)
-                } else {
-                    glassContent
-                }
-            } else {
-                content
-                    .foregroundStyle(style.fallbackTextColor)
-                    .background {
-                        capsule
-                            .fill(style.fallbackFill)
-                    }
-                    .overlay(
-                        capsule.stroke(
-                            style.fallbackStroke.color,
-                            lineWidth: style.fallbackStroke.lineWidth
-                        )
-                    )
-            }
+        let decorated: AnyView
+        if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *), let ns = namespace {
+            decorated = AnyView(
+                pill
+                    .glassEffectID(id, in: ns)
+                    .glassEffectTransition(.matchedGeometry)
+            )
+        } else {
+            decorated = AnyView(pill)
         }
 
-        let base = chipContent
+        let base = decorated
             .scaleEffect(style.scale)
             .animation(.easeOut(duration: 0.15), value: isSelected)
             .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -596,43 +559,25 @@ private struct CategoryChip: View {
 
 // MARK: - Styles
 private struct AddCategoryPillStyle: ButtonStyle {
-    let capabilities: PlatformCapabilities
     let tint: Color
 
     func makeBody(configuration: Configuration) -> some View {
-        let capsule = CategoryPillMetrics.shape
         let isActive = configuration.isPressed
 
-        let label = CategoryPillMetrics.layout {
+        let capsule = Capsule(style: .continuous)
+
+        return CategoryChipPill(
+            isSelected: false,
+            selectionColor: nil,
+            glassForeground: .primary,
+            fallbackForeground: .primary,
+            fallbackFill: .clear
+        ) {
             configuration.label
         }
-
-        return Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                label
-                    .foregroundStyle(.primary)
-                    .glassEffect(.regular.interactive(), in: capsule)
-                    .background {
-                        if isActive {
-                            capsule.fill(tint.opacity(0.25))
-                        }
-                    }
-                    .overlay {
-                        if isActive {
-                            capsule.stroke(tint, lineWidth: 2)
-                        }
-                    }
-            } else {
-                label
-                    .foregroundStyle(.primary)
-                    .background {
-                        capsule.fill(isActive ? tint.opacity(0.18) : DS.Colors.chipFill)
-                    }
-                    .overlay {
-                        if isActive {
-                            capsule.stroke(tint, lineWidth: 2)
-                        }
-                    }
+        .overlay {
+            if isActive {
+                capsule.strokeBorder(tint.opacity(0.45), lineWidth: 1)
             }
         }
         .animation(.easeOut(duration: 0.15), value: isActive)

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -207,21 +207,6 @@ struct AddUnplannedExpenseView: View {
 }
 
 // MARK: - CategoryChipsRow
-/// Shared layout metrics for the category pill controls.
-private enum CategoryPillMetrics {
-    static let controlHeight: CGFloat = 44
-
-    static var shape: Capsule { Capsule(style: .continuous) }
-
-    static func layout<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        content()
-            .padding(.horizontal, DS.Spacing.m)
-            .padding(.vertical, 8)
-            .frame(height: controlHeight, alignment: .center)
-            .contentShape(shape)
-    }
-}
-
 /// Shows a static “Add” pill followed by a horizontally-scrolling list of
 /// category chips (live via @FetchRequest). Selecting a chip updates the binding.
 private struct CategoryChipsRow: View {
@@ -273,7 +258,6 @@ private struct CategoryChipsRow: View {
                                             namespace: glassNamespace
                                         )
                                         .onTapGesture { selectedCategoryID = cat.objectID }
-                                        .glassEffectTransition(.matchedGeometry)
                                     }
                                 }
                             }
@@ -352,7 +336,6 @@ private struct CategoryChipsRow: View {
 /// Compact, fixed “Add” control styled like a pill.
 private struct AddCategoryPill: View {
     var onTap: () -> Void
-    @Environment(\.platformCapabilities) private var capabilities
     @EnvironmentObject private var themeManager: ThemeManager
 
     var body: some View {
@@ -362,7 +345,6 @@ private struct AddCategoryPill: View {
         }
         .buttonStyle(
             AddCategoryPillStyle(
-                capabilities: capabilities,
                 tint: themeManager.selectedTheme.resolvedTint
             )
         )
@@ -384,7 +366,6 @@ private struct CategoryChip: View {
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
-        let capsule = CategoryPillMetrics.shape
         let categoryColor = Color(hex: colorHex) ?? .secondary
         let style = CategoryChipStyle.make(
             isSelected: isSelected,
@@ -392,7 +373,17 @@ private struct CategoryChip: View {
             colorScheme: colorScheme
         )
 
-        let content = CategoryPillMetrics.layout {
+        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
+
+        let pill = CategoryChipPill(
+            isSelected: isSelected,
+            selectionColor: categoryColor,
+            glassForeground: style.glassTextColor,
+            fallbackForeground: style.fallbackTextColor,
+            fallbackFill: style.fallbackFill,
+            fallbackStroke: (!isSelected && style.fallbackStroke.lineWidth > 0) ? style.fallbackStroke : nil,
+            glassStroke: isSelected ? nil : style.glassStroke
+        ) {
             HStack(spacing: DS.Spacing.s) {
                 Circle()
                     .fill(categoryColor)
@@ -402,45 +393,18 @@ private struct CategoryChip: View {
             }
         }
 
-        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
-
-        let chipContent = Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                let glassContent = content
-                    .foregroundStyle(style.glassTextColor)
-                    .glassEffect(
-                        .regular.interactive(),
-                        in: capsule
-                    )
-                    .overlay {
-                        if let stroke = style.glassStroke {
-                            capsule.stroke(stroke.color, lineWidth: stroke.lineWidth)
-                        }
-                    }
-
-                if let ns = namespace {
-                    glassContent
-                        .glassEffectID(id, in: ns)
-                } else {
-                    glassContent
-                }
-            } else {
-                content
-                    .foregroundStyle(style.fallbackTextColor)
-                    .background {
-                        capsule
-                            .fill(style.fallbackFill)
-                    }
-                    .overlay(
-                        capsule.stroke(
-                            style.fallbackStroke.color,
-                            lineWidth: style.fallbackStroke.lineWidth
-                        )
-                    )
-            }
+        let decorated: AnyView
+        if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *), let ns = namespace {
+            decorated = AnyView(
+                pill
+                    .glassEffectID(id, in: ns)
+                    .glassEffectTransition(.matchedGeometry)
+            )
+        } else {
+            decorated = AnyView(pill)
         }
 
-        let base = chipContent
+        let base = decorated
             .scaleEffect(style.scale)
             .animation(.easeOut(duration: 0.15), value: isSelected)
             .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -462,43 +426,25 @@ private struct CategoryChip: View {
 
 // MARK: - Styles
 private struct AddCategoryPillStyle: ButtonStyle {
-    let capabilities: PlatformCapabilities
     let tint: Color
 
     func makeBody(configuration: Configuration) -> some View {
-        let capsule = CategoryPillMetrics.shape
         let isActive = configuration.isPressed
 
-        let label = CategoryPillMetrics.layout {
+        let capsule = Capsule(style: .continuous)
+
+        return CategoryChipPill(
+            isSelected: false,
+            selectionColor: nil,
+            glassForeground: .primary,
+            fallbackForeground: .primary,
+            fallbackFill: .clear
+        ) {
             configuration.label
         }
-
-        return Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                label
-                    .foregroundStyle(.primary)
-                    .glassEffect(.regular.interactive(), in: capsule)
-                    .background {
-                        if isActive {
-                            capsule.fill(tint.opacity(0.25))
-                        }
-                    }
-                    .overlay {
-                        if isActive {
-                            capsule.stroke(tint, lineWidth: 2)
-                        }
-                    }
-            } else {
-                label
-                    .foregroundStyle(.primary)
-                    .background {
-                        capsule.fill(isActive ? tint.opacity(0.18) : DS.Colors.chipFill)
-                    }
-                    .overlay {
-                        if isActive {
-                            capsule.stroke(tint, lineWidth: 2)
-                        }
-                    }
+        .overlay {
+            if isActive {
+                capsule.strokeBorder(tint.opacity(0.45), lineWidth: 1)
             }
         }
         .animation(.easeOut(duration: 0.15), value: isActive)

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -39,8 +39,8 @@ struct CategoryChipStyle {
             return CategoryChipStyle(
                 scale: 1.0,
                 fallbackTextColor: .primary,
-                fallbackFill: DS.Colors.chipFill,
-                fallbackStroke: Stroke(color: DS.Colors.chipFill, lineWidth: 1),
+                fallbackFill: .clear,
+                fallbackStroke: Stroke(color: .clear, lineWidth: 0),
                 glassTextColor: .primary,
                 glassStroke: nil,
                 shadowColor: .clear,

--- a/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
+++ b/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
@@ -6,6 +6,88 @@
 //
 import SwiftUI
 
+// MARK: - CategoryChipPill
+struct CategoryChipPill<Label: View>: View {
+    let isSelected: Bool
+    let selectionColor: Color?
+    let glassForeground: Color
+    let fallbackForeground: Color
+    let fallbackFill: Color
+    let fallbackStroke: CategoryChipStyle.Stroke?
+    let glassStroke: CategoryChipStyle.Stroke?
+    @ViewBuilder var label: () -> Label
+
+    @Environment(\.platformCapabilities) private var capabilities
+
+    init(
+        isSelected: Bool,
+        selectionColor: Color?,
+        glassForeground: Color = .primary,
+        fallbackForeground: Color = .primary,
+        fallbackFill: Color = DS.Colors.chipFill,
+        fallbackStroke: CategoryChipStyle.Stroke? = nil,
+        glassStroke: CategoryChipStyle.Stroke? = nil,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.isSelected = isSelected
+        self.selectionColor = selectionColor
+        self.glassForeground = glassForeground
+        self.fallbackForeground = fallbackForeground
+        self.fallbackFill = fallbackFill
+        self.fallbackStroke = fallbackStroke
+        self.glassStroke = glassStroke
+        self.label = label
+    }
+
+    var body: some View {
+        let capsule = Capsule(style: .continuous)
+
+        let content = label()
+            .padding(.horizontal, DS.Spacing.m)
+            .frame(height: 44)
+            .contentShape(capsule)
+
+        let base = Group {
+            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
+                var glass = content
+                    .foregroundStyle(glassForeground)
+                    .glassEffect(.regular, in: capsule)
+
+                if let stroke = glassStroke {
+                    glass = glass.overlay {
+                        capsule.strokeBorder(stroke.color, lineWidth: stroke.lineWidth)
+                    }
+                }
+
+                glass
+            } else {
+                var fallback = content
+                    .foregroundStyle(fallbackForeground)
+                    .background {
+                        capsule.fill(fallbackFill)
+                    }
+
+                if let stroke = fallbackStroke, stroke.lineWidth > 0 {
+                    fallback = fallback.overlay {
+                        capsule.strokeBorder(stroke.color, lineWidth: stroke.lineWidth)
+                    }
+                }
+
+                fallback
+            }
+        }
+
+        return base
+            .frame(height: 44)
+            .overlay {
+                if isSelected {
+                    let strokeColor = selectionColor ?? .accentColor
+                    capsule.strokeBorder(strokeColor, lineWidth: 2)
+                }
+            }
+    }
+}
+
 // MARK: - CategoryTotalsRow
 /// Horizontally scrolling pills showing spend per category.
 struct CategoryTotalsRow: View {
@@ -25,23 +107,22 @@ struct CategoryTotalsRow: View {
                     ScrollView(.horizontal, showsIndicators: false) {
                         LazyHStack(spacing: DS.Spacing.s) {
                             ForEach(categories) { cat in
-                                let capsule = Capsule(style: .continuous)
-                                let content = HStack(spacing: DS.Spacing.s) {
-                                    Circle()
-                                        .fill(Color(hex: cat.hexColor ?? "#999999") ?? .secondary)
-                                        .frame(width: chipDotSize, height: chipDotSize)
-                                    Text(cat.categoryName)
-                                        .font(chipFont)
-                                    Text(CurrencyFormatterHelper.string(for: cat.amount))
-                                        .font(chipFont)
+                                CategoryChipPill(
+                                    isSelected: false,
+                                    selectionColor: nil
+                                ) {
+                                    HStack(spacing: DS.Spacing.s) {
+                                        Circle()
+                                            .fill(Color(hex: cat.hexColor ?? "#999999") ?? .secondary)
+                                            .frame(width: chipDotSize, height: chipDotSize)
+                                        Text(cat.categoryName)
+                                            .font(chipFont)
+                                        Text(CurrencyFormatterHelper.string(for: cat.amount))
+                                            .font(chipFont)
+                                    }
                                 }
-                                .padding(.horizontal, DS.Spacing.m)
-                                .frame(height: controlHeight)
-
-                                content
-                                    .glassEffect(.regular, in: capsule)
-                                    .glassEffectID(String(describing: cat.id), in: glassNamespace)
-                                    .glassEffectTransition(.matchedGeometry)
+                                .glassEffectID(String(describing: cat.id), in: glassNamespace)
+                                .glassEffectTransition(.matchedGeometry)
                             }
                         }
                         .padding(.horizontal, horizontalInset)
@@ -52,21 +133,20 @@ struct CategoryTotalsRow: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(spacing: DS.Spacing.s) {
                         ForEach(categories) { cat in
-                            let content = HStack(spacing: DS.Spacing.s) {
-                                Circle()
-                                    .fill(Color(hex: cat.hexColor ?? "#999999") ?? .secondary)
-                                    .frame(width: chipDotSize, height: chipDotSize)
-                                Text(cat.categoryName)
-                                    .font(chipFont)
-                                Text(CurrencyFormatterHelper.string(for: cat.amount))
-                                    .font(chipFont)
+                            CategoryChipPill(
+                                isSelected: false,
+                                selectionColor: nil
+                            ) {
+                                HStack(spacing: DS.Spacing.s) {
+                                    Circle()
+                                        .fill(Color(hex: cat.hexColor ?? "#999999") ?? .secondary)
+                                        .frame(width: chipDotSize, height: chipDotSize)
+                                    Text(cat.categoryName)
+                                        .font(chipFont)
+                                    Text(CurrencyFormatterHelper.string(for: cat.amount))
+                                        .font(chipFont)
+                                }
                             }
-                            .padding(.horizontal, DS.Spacing.m)
-                            .frame(height: controlHeight)
-                            content
-                                .background(
-                                    Capsule().fill(DS.Colors.chipFill)
-                                )
                         }
                     }
                     .padding(.horizontal, horizontalInset)


### PR DESCRIPTION
## Summary
- introduce a reusable `CategoryChipPill` to standardize the 44pt capsule layout used by category chips
- refactor the planned and unplanned expense chip rows and “Add” pill styles to use the shared helper with strokeBorder-based selection rings
- clear the idle chip fallback background to remove the gray halo while keeping Home’s appearance intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e139673d08832cacbac8fc6a9538ae