### PR TITLE
Align category chip pills across add forms

### DIFF
--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -207,21 +207,6 @@ struct AddUnplannedExpenseView: View {
 }
 
 // MARK: - CategoryChipsRow
-/// Shared layout metrics for the category pill controls.
-private enum CategoryPillMetrics {
-    static let controlHeight: CGFloat = 44
-
-    static var shape: Capsule { Capsule(style: .continuous) }
-
-    static func layout<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        content()
-            .padding(.horizontal, DS.Spacing.m)
-            .padding(.vertical, 8)
-            .frame(height: controlHeight, alignment: .center)
-            .contentShape(shape)
-    }
-}
-
 /// Shows a static “Add” pill followed by a horizontally-scrolling list of
 /// category chips (live via @FetchRequest). Selecting a chip updates the binding.
 private struct CategoryChipsRow: View {
@@ -362,7 +347,6 @@ private struct AddCategoryPill: View {
         }
         .buttonStyle(
             AddCategoryPillStyle(
-                capabilities: capabilities,
                 tint: themeManager.selectedTheme.resolvedTint
             )
         )
@@ -380,11 +364,9 @@ private struct CategoryChip: View {
     let isSelected: Bool
     let namespace: Namespace.ID?
     @Environment(\.platformCapabilities) private var capabilities
-    @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
-        let capsule = CategoryPillMetrics.shape
         let categoryColor = Color(hex: colorHex) ?? .secondary
         let style = CategoryChipStyle.make(
             isSelected: isSelected,
@@ -392,7 +374,23 @@ private struct CategoryChip: View {
             colorScheme: colorScheme
         )
 
-        let content = CategoryPillMetrics.layout {
+        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
+
+        func convertStroke(_ stroke: CategoryChipStyle.Stroke?) -> CategoryChipPill<EmptyView>.Stroke? {
+            guard let stroke, stroke.lineWidth > 0 else { return nil }
+            return .init(color: stroke.color, lineWidth: stroke.lineWidth)
+        }
+
+        let glassStroke = convertStroke(style.glassStroke)
+        let fallbackStroke = convertStroke(style.fallbackStroke)
+
+        var chip = CategoryChipPill(
+            isSelected: isSelected,
+            selectionColor: categoryColor,
+            glassStroke: glassStroke,
+            fallbackFill: style.fallbackFill,
+            fallbackStroke: fallbackStroke
+        ) {
             HStack(spacing: DS.Spacing.s) {
                 Circle()
                     .fill(categoryColor)
@@ -402,45 +400,19 @@ private struct CategoryChip: View {
             }
         }
 
-        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
+        if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
+            chip = chip
+                .foregroundStyle(style.glassTextColor)
+                .glassEffectTransition(.matchedGeometry)
 
-        let chipContent = Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                let glassContent = content
-                    .foregroundStyle(style.glassTextColor)
-                    .glassEffect(
-                        .regular.interactive(),
-                        in: capsule
-                    )
-                    .overlay {
-                        if let stroke = style.glassStroke {
-                            capsule.stroke(stroke.color, lineWidth: stroke.lineWidth)
-                        }
-                    }
-
-                if let ns = namespace {
-                    glassContent
-                        .glassEffectID(id, in: ns)
-                } else {
-                    glassContent
-                }
-            } else {
-                content
-                    .foregroundStyle(style.fallbackTextColor)
-                    .background {
-                        capsule
-                            .fill(style.fallbackFill)
-                    }
-                    .overlay(
-                        capsule.stroke(
-                            style.fallbackStroke.color,
-                            lineWidth: style.fallbackStroke.lineWidth
-                        )
-                    )
+            if let ns = namespace {
+                chip = chip.glassEffectID(id, in: ns)
             }
+        } else {
+            chip = chip.foregroundStyle(style.fallbackTextColor)
         }
 
-        let base = chipContent
+        let base = chip
             .scaleEffect(style.scale)
             .animation(.easeOut(duration: 0.15), value: isSelected)
             .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -462,45 +434,25 @@ private struct CategoryChip: View {
 
 // MARK: - Styles
 private struct AddCategoryPillStyle: ButtonStyle {
-    let capabilities: PlatformCapabilities
     let tint: Color
 
     func makeBody(configuration: Configuration) -> some View {
-        let capsule = CategoryPillMetrics.shape
         let isActive = configuration.isPressed
-
-        let label = CategoryPillMetrics.layout {
+        let pill = CategoryChipPill(
+            isSelected: false,
+            selectionColor: nil
+        ) {
             configuration.label
         }
 
-        return Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                label
-                    .foregroundStyle(.primary)
-                    .glassEffect(.regular.interactive(), in: capsule)
-                    .background {
-                        if isActive {
-                            capsule.fill(tint.opacity(0.25))
-                        }
-                    }
-                    .overlay {
-                        if isActive {
-                            capsule.stroke(tint, lineWidth: 2)
-                        }
-                    }
-            } else {
-                label
-                    .foregroundStyle(.primary)
-                    .background {
-                        capsule.fill(isActive ? tint.opacity(0.18) : DS.Colors.chipFill)
-                    }
-                    .overlay {
-                        if isActive {
-                            capsule.stroke(tint, lineWidth: 2)
-                        }
-                    }
+        return pill
+            .foregroundStyle(.primary)
+            .overlay {
+                if isActive {
+                    Capsule(style: .continuous)
+                        .strokeBorder(tint.opacity(0.35), lineWidth: 1.5)
+                }
             }
-        }
-        .animation(.easeOut(duration: 0.15), value: isActive)
+            .animation(.easeOut(duration: 0.15), value: isActive)
     }
 }

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -22,15 +22,13 @@ struct CategoryChipStyle {
         colorScheme: ColorScheme
     ) -> CategoryChipStyle {
         if isSelected {
-            let strokeColor = categoryColor
-
             return CategoryChipStyle(
                 scale: 1.0,
                 fallbackTextColor: .primary,
                 fallbackFill: .clear,
-                fallbackStroke: Stroke(color: strokeColor, lineWidth: 2),
+                fallbackStroke: Stroke(color: .clear, lineWidth: 0),
                 glassTextColor: .primary,
-                glassStroke: Stroke(color: strokeColor, lineWidth: 2),
+                glassStroke: nil,
                 shadowColor: .clear,
                 shadowRadius: 0,
                 shadowY: 0
@@ -39,8 +37,8 @@ struct CategoryChipStyle {
             return CategoryChipStyle(
                 scale: 1.0,
                 fallbackTextColor: .primary,
-                fallbackFill: DS.Colors.chipFill,
-                fallbackStroke: Stroke(color: DS.Colors.chipFill, lineWidth: 1),
+                fallbackFill: .clear,
+                fallbackStroke: Stroke(color: .clear, lineWidth: 0),
                 glassTextColor: .primary,
                 glassStroke: nil,
                 shadowColor: .clear,


### PR DESCRIPTION
## Summary
- introduce a reusable `CategoryChipPill` so Home and add expense flows share the same 44 pt capsule
- refactor planned and unplanned expense category chips and the add button style to use the shared pill and strokeBorder outlines
- clear the fallback styling so idle chips no longer render a gray halo

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e139673d08832cacbac8fc6a9538ae