### PR TITLE
Align category chip pills with shared layout

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -355,20 +355,6 @@ struct AddPlannedExpenseView: View {
 
 // MARK: - CategoryChipsRow
 /// Shared layout metrics for the category pill controls.
-private enum CategoryPillMetrics {
-    static let controlHeight: CGFloat = 44
-
-    static var shape: Capsule { Capsule(style: .continuous) }
-
-    static func layout<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        content()
-            .padding(.horizontal, DS.Spacing.m)
-            .padding(.vertical, 8)
-            .frame(height: controlHeight, alignment: .center)
-            .contentShape(shape)
-    }
-}
-
 /// Reusable horizontally scrolling row of category chips with an Add button.
 private struct CategoryChipsRow: View {
 
@@ -487,7 +473,6 @@ private struct PresentationDetentsCompat: ViewModifier {
 // MARK: - AddCategoryPill
 private struct AddCategoryPill: View {
     var onTap: () -> Void
-    @Environment(\.platformCapabilities) private var capabilities
     @EnvironmentObject private var themeManager: ThemeManager
 
     var body: some View {
@@ -497,7 +482,6 @@ private struct AddCategoryPill: View {
         }
         .buttonStyle(
             AddCategoryPillStyle(
-                capabilities: capabilities,
                 tint: themeManager.selectedTheme.resolvedTint
             )
         )
@@ -514,11 +498,9 @@ private struct CategoryChip: View {
     let isSelected: Bool
     let namespace: Namespace.ID?
     @Environment(\.platformCapabilities) private var capabilities
-    @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
-        let capsule = CategoryPillMetrics.shape
         let categoryColor = Color(hex: colorHex) ?? .secondary
         let style = CategoryChipStyle.make(
             isSelected: isSelected,
@@ -526,7 +508,15 @@ private struct CategoryChip: View {
             colorScheme: colorScheme
         )
 
-        let content = CategoryPillMetrics.layout {
+        let pill = CategoryChipPill(
+            isSelected: isSelected,
+            selectionColor: isSelected ? categoryColor : nil,
+            glassTextColor: style.glassTextColor,
+            fallbackTextColor: style.fallbackTextColor,
+            fallbackFill: style.fallbackFill,
+            fallbackStrokeColor: style.fallbackStroke.color,
+            fallbackStrokeLineWidth: style.fallbackStroke.lineWidth
+        ) {
             HStack(spacing: DS.Spacing.s) {
                 Circle()
                     .fill(categoryColor)
@@ -536,48 +526,25 @@ private struct CategoryChip: View {
             }
         }
 
-        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
-
-        let chipContent = Group {
+        let resolvedChip = Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                let glassContent = content
-                    .foregroundStyle(style.glassTextColor)
-                    .glassEffect(
-                        .regular.interactive(),
-                        in: capsule
-                    )
-                    .overlay {
-                        if let stroke = style.glassStroke {
-                            capsule.stroke(stroke.color, lineWidth: stroke.lineWidth)
-                        }
-                    }
-
                 if let ns = namespace {
-                    glassContent
+                    pill
                         .glassEffectID(id, in: ns)
                 } else {
-                    glassContent
+                    pill
                 }
             } else {
-                content
-                    .foregroundStyle(style.fallbackTextColor)
-                    .background {
-                        capsule
-                            .fill(style.fallbackFill)
-                    }
-                    .overlay(
-                        capsule.stroke(
-                            style.fallbackStroke.color,
-                            lineWidth: style.fallbackStroke.lineWidth
-                        )
-                    )
+                pill
             }
         }
 
-        let base = chipContent
+        let base = resolvedChip
             .scaleEffect(style.scale)
             .animation(.easeOut(duration: 0.15), value: isSelected)
             .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
 
         if shouldApplyShadow {
             base
@@ -596,43 +563,28 @@ private struct CategoryChip: View {
 
 // MARK: - Styles
 private struct AddCategoryPillStyle: ButtonStyle {
-    let capabilities: PlatformCapabilities
     let tint: Color
 
     func makeBody(configuration: Configuration) -> some View {
-        let capsule = CategoryPillMetrics.shape
         let isActive = configuration.isPressed
 
-        let label = CategoryPillMetrics.layout {
-            configuration.label
-        }
+        let capsule = Capsule(style: .continuous)
 
-        return Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                label
-                    .foregroundStyle(.primary)
-                    .glassEffect(.regular.interactive(), in: capsule)
-                    .background {
-                        if isActive {
-                            capsule.fill(tint.opacity(0.25))
-                        }
-                    }
-                    .overlay {
-                        if isActive {
-                            capsule.stroke(tint, lineWidth: 2)
-                        }
-                    }
-            } else {
-                label
-                    .foregroundStyle(.primary)
-                    .background {
-                        capsule.fill(isActive ? tint.opacity(0.18) : DS.Colors.chipFill)
-                    }
-                    .overlay {
-                        if isActive {
-                            capsule.stroke(tint, lineWidth: 2)
-                        }
-                    }
+        return CategoryChipPill(
+            isSelected: false,
+            selectionColor: nil,
+            glassTextColor: .primary,
+            fallbackTextColor: .primary,
+            fallbackFill: DS.Colors.chipFill,
+            fallbackStrokeColor: DS.Colors.chipFill,
+            fallbackStrokeLineWidth: 1
+        ) {
+            configuration.label
+                .font(.subheadline.weight(.semibold))
+        }
+        .overlay {
+            if isActive {
+                capsule.strokeBorder(tint.opacity(0.35), lineWidth: 2)
             }
         }
         .animation(.easeOut(duration: 0.15), value: isActive)

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -22,15 +22,13 @@ struct CategoryChipStyle {
         colorScheme: ColorScheme
     ) -> CategoryChipStyle {
         if isSelected {
-            let strokeColor = categoryColor
-
             return CategoryChipStyle(
                 scale: 1.0,
                 fallbackTextColor: .primary,
                 fallbackFill: .clear,
-                fallbackStroke: Stroke(color: strokeColor, lineWidth: 2),
+                fallbackStroke: Stroke(color: .clear, lineWidth: 0),
                 glassTextColor: .primary,
-                glassStroke: Stroke(color: strokeColor, lineWidth: 2),
+                glassStroke: nil,
                 shadowColor: .clear,
                 shadowRadius: 0,
                 shadowY: 0
@@ -39,8 +37,8 @@ struct CategoryChipStyle {
             return CategoryChipStyle(
                 scale: 1.0,
                 fallbackTextColor: .primary,
-                fallbackFill: DS.Colors.chipFill,
-                fallbackStroke: Stroke(color: DS.Colors.chipFill, lineWidth: 1),
+                fallbackFill: .clear,
+                fallbackStroke: Stroke(color: .clear, lineWidth: 0),
                 glassTextColor: .primary,
                 glassStroke: nil,
                 shadowColor: .clear,

--- a/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
+++ b/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
@@ -6,6 +6,80 @@
 //
 import SwiftUI
 
+// MARK: - CategoryChipPill
+struct CategoryChipPill<Label: View>: View {
+    private let controlHeight: CGFloat = 44
+    private var capsule: Capsule { Capsule(style: .continuous) }
+
+    let isSelected: Bool
+    let selectionColor: Color?
+    let glassTextColor: Color
+    let fallbackTextColor: Color
+    let fallbackFill: Color
+    let fallbackStrokeColor: Color
+    let fallbackStrokeLineWidth: CGFloat
+    @ViewBuilder var label: () -> Label
+
+    @Environment(\.platformCapabilities) private var capabilities
+
+    init(
+        isSelected: Bool,
+        selectionColor: Color? = nil,
+        glassTextColor: Color = .primary,
+        fallbackTextColor: Color = .primary,
+        fallbackFill: Color = DS.Colors.chipFill,
+        fallbackStrokeColor: Color = DS.Colors.chipFill,
+        fallbackStrokeLineWidth: CGFloat = 1,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.isSelected = isSelected
+        self.selectionColor = selectionColor
+        self.glassTextColor = glassTextColor
+        self.fallbackTextColor = fallbackTextColor
+        self.fallbackFill = fallbackFill
+        self.fallbackStrokeColor = fallbackStrokeColor
+        self.fallbackStrokeLineWidth = fallbackStrokeLineWidth
+        self.label = label
+    }
+
+    var body: some View {
+        Group {
+            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
+                baseLabel
+                    .foregroundStyle(glassTextColor)
+                    .glassEffect(.regular, in: capsule)
+            } else {
+                baseLabel
+                    .foregroundStyle(fallbackTextColor)
+                    .background {
+                        capsule.fill(fallbackFill)
+                    }
+                    .overlay {
+                        if fallbackStrokeLineWidth > 0 {
+                            capsule.strokeBorder(
+                                fallbackStrokeColor,
+                                lineWidth: fallbackStrokeLineWidth
+                            )
+                        }
+                    }
+            }
+        }
+        .overlay {
+            if isSelected, let selectionColor {
+                capsule.strokeBorder(selectionColor, lineWidth: 2)
+            }
+        }
+        .frame(height: controlHeight)
+    }
+
+    private var baseLabel: some View {
+        label()
+            .padding(.horizontal, DS.Spacing.m)
+            .frame(height: controlHeight, alignment: .center)
+            .contentShape(capsule)
+    }
+}
+
 // MARK: - CategoryTotalsRow
 /// Horizontally scrolling pills showing spend per category.
 struct CategoryTotalsRow: View {
@@ -22,62 +96,54 @@ struct CategoryTotalsRow: View {
         Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
                 GlassEffectContainer(spacing: DS.Spacing.s) {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        LazyHStack(spacing: DS.Spacing.s) {
-                            ForEach(categories) { cat in
-                                let capsule = Capsule(style: .continuous)
-                                let content = HStack(spacing: DS.Spacing.s) {
-                                    Circle()
-                                        .fill(Color(hex: cat.hexColor ?? "#999999") ?? .secondary)
-                                        .frame(width: chipDotSize, height: chipDotSize)
-                                    Text(cat.categoryName)
-                                        .font(chipFont)
-                                    Text(CurrencyFormatterHelper.string(for: cat.amount))
-                                        .font(chipFont)
-                                }
-                                .padding(.horizontal, DS.Spacing.m)
-                                .frame(height: controlHeight)
-
-                                content
-                                    .glassEffect(.regular, in: capsule)
-                                    .glassEffectID(String(describing: cat.id), in: glassNamespace)
-                                    .glassEffectTransition(.matchedGeometry)
-                            }
-                        }
-                        .padding(.horizontal, horizontalInset)
-                    }
-                    .allowsHitTesting(isInteractive)
+                    chipScrollContent
                 }
             } else {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    LazyHStack(spacing: DS.Spacing.s) {
-                        ForEach(categories) { cat in
-                            let content = HStack(spacing: DS.Spacing.s) {
-                                Circle()
-                                    .fill(Color(hex: cat.hexColor ?? "#999999") ?? .secondary)
-                                    .frame(width: chipDotSize, height: chipDotSize)
-                                Text(cat.categoryName)
-                                    .font(chipFont)
-                                Text(CurrencyFormatterHelper.string(for: cat.amount))
-                                    .font(chipFont)
-                            }
-                            .padding(.horizontal, DS.Spacing.m)
-                            .frame(height: controlHeight)
-                            content
-                                .background(
-                                    Capsule().fill(DS.Colors.chipFill)
-                                )
-                        }
-                    }
-                    .padding(.horizontal, horizontalInset)
-                }
-//                .allowsHitTesting(isInteractive)
+                chipScrollContent
             }
         }
         .ub_hideScrollIndicators()
         .frame(height: controlHeight)
         .opacity(isPlaceholder ? 0 : 1)
         .accessibilityHidden(isPlaceholder)
+    }
+
+    @ViewBuilder
+    private var chipScrollContent: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: DS.Spacing.s) {
+                ForEach(categories) { cat in
+                    let pill = CategoryChipPill(
+                        isSelected: false,
+                        selectionColor: nil,
+                        glassTextColor: .primary,
+                        fallbackTextColor: .primary,
+                        fallbackFill: DS.Colors.chipFill,
+                        fallbackStrokeColor: DS.Colors.chipFill,
+                        fallbackStrokeLineWidth: 1
+                    ) {
+                        HStack(spacing: DS.Spacing.s) {
+                            Circle()
+                                .fill(Color(hex: cat.hexColor ?? "#999999") ?? .secondary)
+                                .frame(width: chipDotSize, height: chipDotSize)
+                            Text(cat.categoryName)
+                                .font(chipFont)
+                            Text(CurrencyFormatterHelper.string(for: cat.amount))
+                                .font(chipFont)
+                        }
+                    }
+                    if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
+                        pill
+                            .glassEffectID(String(describing: cat.id), in: glassNamespace)
+                            .glassEffectTransition(.matchedGeometry)
+                    } else {
+                        pill
+                    }
+                }
+            }
+            .padding(.horizontal, horizontalInset)
+        }
+        .allowsHitTesting(isInteractive)
     }
 
     // Slightly larger, easier to read, and fills the row visually.


### PR DESCRIPTION
## Summary
- extract a reusable `CategoryChipPill` to share the 44 pt capsule layout across the home totals row and add expense chips
- refactor the planned and unplanned expense forms to adopt the shared pill and update the "+ Add" button feedback with `strokeBorder`
- clear idle chip backgrounds in `CategoryChipStyle` so unselected chips render without halos

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e139673d08832cacbac8fc6a9538ae