### PR TITLE
Adjust Catalyst navigation chrome background

### DIFF
--- a/OffshoreBudgeting/Systems/Compatibility.swift
+++ b/OffshoreBudgeting/Systems/Compatibility.swift
@@ -341,11 +341,15 @@ private struct UBRootNavigationChromeModifier: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
         if UBGlassBackgroundPolicy.shouldUseSystemChrome(capabilities: capabilities) {
-            if #available(iOS 16.0, macCatalyst 16.0, *) {
+            #if targetEnvironment(macCatalyst)
+            content
+            #else
+            if #available(iOS 16.0, *) {
                 content.toolbarBackground(.hidden, for: .navigationBar)
             } else {
                 content
             }
+            #endif
         } else {
             content
         }


### PR DESCRIPTION
## Summary
- ensure macCatalyst builds defer to system navigation chrome when OS 26 translucency is available
- keep the hidden navigation toolbar background for iOS platforms to preserve the legacy appearance

## Testing
- not run (requires macOS Catalyst tooling)

------
https://chatgpt.com/codex/tasks/task_e_68e14003c4f8832c9e7ecc4354ce1c4b