### PR TITLE
Adopt RootHeaderGlass controls for toolbar add buttons

### DIFF
--- a/OffshoreBudgeting/Views/CardsView.swift
+++ b/OffshoreBudgeting/Views/CardsView.swift
@@ -116,18 +116,41 @@ struct CardsView: View {
         .tint(themeManager.selectedTheme.resolvedTint)
     }
 
+    @ViewBuilder
     private var addActionToolbarButton: some View {
-        Button {
-            if selectedCardStableID == nil {
-                isPresentingAddCard = true
-            } else {
-                isPresentingAddExpense = true
+        let iconDimension = RootHeaderActionMetrics.iconDimension(for: capabilities, width: nil)
+
+        if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            Button {
+                if selectedCardStableID == nil {
+                    isPresentingAddCard = true
+                } else {
+                    isPresentingAddExpense = true
+                }
+            } label: {
+                RootHeaderGlassControl(sizing: .icon) {
+                    RootHeaderControlIcon(systemImage: "plus")
+                        .frame(width: iconDimension, height: iconDimension)
+                }
             }
-        } label: {
-            Image(systemName: "plus")
-                //.imageScale(.medium)
+            .buttonStyle(.glass)
+            .accessibilityLabel(selectedCardStableID == nil ? "Add Card" : "Add Expense")
+        } else {
+            Button {
+                if selectedCardStableID == nil {
+                    isPresentingAddCard = true
+                } else {
+                    isPresentingAddExpense = true
+                }
+            } label: {
+                RootHeaderGlassControl(sizing: .icon) {
+                    RootHeaderControlIcon(systemImage: "plus")
+                        .frame(width: iconDimension, height: iconDimension)
+                }
+            }
+            .buttonStyle(RootHeaderActionButtonStyle())
+            .accessibilityLabel(selectedCardStableID == nil ? "Add Card" : "Add Expense")
         }
-        .accessibilityLabel(selectedCardStableID == nil ? "Add Card" : "Add Expense")
     }
 
     // MARK: - Content View (Type-Safe)

--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -171,12 +171,31 @@ struct IncomeView: View {
         addIncomeInitialDate = AddIncomeSheetDate(value: baseDate)
     }
 
+    @ViewBuilder
     private var addIncomeButton: some View {
-        Button(action: { beginAddingIncome() }) {
-            Image(systemName: "plus")
+        let iconDimension = RootHeaderActionMetrics.iconDimension(for: capabilities, width: nil)
+
+        if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            Button(action: { beginAddingIncome() }) {
+                RootHeaderGlassControl(sizing: .icon) {
+                    RootHeaderControlIcon(systemImage: "plus")
+                        .frame(width: iconDimension, height: iconDimension)
+                }
+            }
+            .buttonStyle(.glass)
+            .accessibilityLabel("Add Income")
+            .accessibilityIdentifier("add_income_button")
+        } else {
+            Button(action: { beginAddingIncome() }) {
+                RootHeaderGlassControl(sizing: .icon) {
+                    RootHeaderControlIcon(systemImage: "plus")
+                        .frame(width: iconDimension, height: iconDimension)
+                }
+            }
+            .buttonStyle(RootHeaderActionButtonStyle())
+            .accessibilityLabel("Add Income")
+            .accessibilityIdentifier("add_income_button")
         }
-        .accessibilityLabel("Add Income")
-        .accessibilityIdentifier("add_income_button")
     }
 
     // MARK: Calendar

--- a/OffshoreBudgeting/Views/PresetsView.swift
+++ b/OffshoreBudgeting/Views/PresetsView.swift
@@ -170,11 +170,29 @@ struct PresetsView: View {
         .navigationTitle("Presets")
     }
 
+    @ViewBuilder
     private var addPresetToolbarButton: some View {
-        Button(action: { isPresentingAddSheet = true }) {
-            Image(systemName: "plus")
+        let iconDimension = RootHeaderActionMetrics.iconDimension(for: capabilities, width: nil)
+
+        if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            Button(action: { isPresentingAddSheet = true }) {
+                RootHeaderGlassControl(sizing: .icon) {
+                    RootHeaderControlIcon(systemImage: "plus")
+                        .frame(width: iconDimension, height: iconDimension)
+                }
+            }
+            .buttonStyle(.glass)
+            .accessibilityLabel("Add Preset Planned Expense")
+        } else {
+            Button(action: { isPresentingAddSheet = true }) {
+                RootHeaderGlassControl(sizing: .icon) {
+                    RootHeaderControlIcon(systemImage: "plus")
+                        .frame(width: iconDimension, height: iconDimension)
+                }
+            }
+            .buttonStyle(RootHeaderActionButtonStyle())
+            .accessibilityLabel("Add Preset Planned Expense")
         }
-        .accessibilityLabel("Add Preset Planned Expense")
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary
- wrap the income toolbar add button in RootHeaderGlassControl so OS 26 gains the glass capsule while legacy systems still render the fallback
- update the cards toolbar add button to use the shared glass control and keep the add-card/add-expense logic intact
- restyle the presets toolbar add button with RootHeaderGlassControl and fallback animation for older OS versions

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e141c8d5f4832c88de0f3cb7f384dc