### PR TITLE
Enable system theme glass on OS 26

### DIFF
--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -473,7 +473,11 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
     var usesGlassMaterials: Bool {
         switch self {
         case .system:
-            return false
+            if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+                return true
+            } else {
+                return false
+            }
         default:
             return true
         }


### PR DESCRIPTION
## Summary
- allow the System theme to opt into glass materials when running on OS 26 or newer
- verified that UBGlassBackgroundPolicy surfaces and navigation backgrounds continue to route OS 26 builds to glass while legacy versions keep legacy chrome

## Testing
- not run (environment does not include macOS 26 simulators)

------
https://chatgpt.com/codex/tasks/task_e_68e1438350dc832c8cfcbedb37e78a76