### PR TITLE
Improve category chip selection contrast

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -512,7 +512,7 @@ private struct CategoryChip: View {
 
         let pill = CategoryChipPill(
             isSelected: isSelected,
-            selectionColor: isSelected ? categoryColor : nil,
+            selectionColor: isSelected ? (style.glassStroke?.color ?? categoryColor) : nil,
             glassTextColor: style.glassTextColor,
             fallbackTextColor: style.fallbackTextColor,
             fallbackFill: style.fallbackFill,

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -378,7 +378,7 @@ private struct CategoryChip: View {
 
         let pill = CategoryChipPill(
             isSelected: isSelected,
-            selectionColor: isSelected ? categoryColor : nil,
+            selectionColor: isSelected ? (style.glassStroke?.color ?? categoryColor) : nil,
             glassTextColor: style.glassTextColor,
             fallbackTextColor: style.fallbackTextColor,
             fallbackFill: style.fallbackFill,

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct CategoryChipStyle {
     struct Stroke {
@@ -21,24 +24,14 @@ struct CategoryChipStyle {
         categoryColor: Color,
         colorScheme: ColorScheme
     ) -> CategoryChipStyle {
-        if isSelected {
+        let neutralStroke = Stroke(color: DS.Colors.chipFill, lineWidth: 1)
+
+        guard isSelected else {
             return CategoryChipStyle(
                 scale: 1.0,
                 fallbackTextColor: .primary,
-                fallbackFill: .clear,
-                fallbackStroke: Stroke(color: .clear, lineWidth: 0),
-                glassTextColor: .primary,
-                glassStroke: nil,
-                shadowColor: .clear,
-                shadowRadius: 0,
-                shadowY: 0
-            )
-        } else {
-            return CategoryChipStyle(
-                scale: 1.0,
-                fallbackTextColor: .primary,
-                fallbackFill: .clear,
-                fallbackStroke: Stroke(color: .clear, lineWidth: 0),
+                fallbackFill: DS.Colors.chipFill,
+                fallbackStroke: neutralStroke,
                 glassTextColor: .primary,
                 glassStroke: nil,
                 shadowColor: .clear,
@@ -46,5 +39,86 @@ struct CategoryChipStyle {
                 shadowY: 0
             )
         }
+
+        let selectionFill = tintedColor(
+            baseNeutral: DS.Colors.chipSelectedFill,
+            accent: categoryColor,
+            fraction: 0.4,
+            colorScheme: colorScheme,
+            fallbackOpacity: 0.22
+        )
+
+        let selectionStroke = tintedColor(
+            baseNeutral: DS.Colors.chipSelectedStroke,
+            accent: categoryColor,
+            fraction: 0.65,
+            colorScheme: colorScheme,
+            fallbackOpacity: 0.75
+        )
+
+        return CategoryChipStyle(
+            scale: 1.0,
+            fallbackTextColor: .primary,
+            fallbackFill: selectionFill,
+            fallbackStroke: Stroke(color: selectionStroke, lineWidth: 1.5),
+            glassTextColor: .primary,
+            glassStroke: Stroke(color: selectionStroke, lineWidth: 2),
+            shadowColor: .clear,
+            shadowRadius: 0,
+            shadowY: 0
+        )
     }
+}
+
+// MARK: - Private Helpers
+
+private extension CategoryChipStyle {
+    static func tintedColor(
+        baseNeutral: Color,
+        accent: Color,
+        fraction: CGFloat,
+        colorScheme: ColorScheme,
+        fallbackOpacity: Double
+    ) -> Color {
+        #if canImport(UIKit)
+        let clampedFraction = max(0, min(1, fraction))
+        let traitCollection = UITraitCollection(userInterfaceStyle: colorScheme == .dark ? .dark : .light)
+
+        if #available(iOS 14.0, macCatalyst 14.0, *) {
+            let baseColor = UIColor(baseNeutral).resolvedColor(with: traitCollection)
+            let accentColor = UIColor(accent).resolvedColor(with: traitCollection)
+
+            if let blended = blend(baseColor, with: accentColor, fraction: clampedFraction) {
+                return Color(uiColor: blended)
+            }
+        }
+        #endif
+
+        return accent.opacity(fallbackOpacity)
+    }
+
+    #if canImport(UIKit)
+    private static func blend(
+        _ base: UIColor,
+        with accent: UIColor,
+        fraction: CGFloat
+    ) -> UIColor? {
+        let t = max(0, min(1, fraction))
+
+        var br: CGFloat = 0, bg: CGFloat = 0, bb: CGFloat = 0, ba: CGFloat = 0
+        var ar: CGFloat = 0, ag: CGFloat = 0, ab: CGFloat = 0, aa: CGFloat = 0
+
+        guard base.getRed(&br, green: &bg, blue: &bb, alpha: &ba),
+              accent.getRed(&ar, green: &ag, blue: &ab, alpha: &aa) else {
+            return nil
+        }
+
+        let r = br + (ar - br) * t
+        let g = bg + (ag - bg) * t
+        let b = bb + (ab - bb) * t
+        let a = ba + (aa - ba) * t
+
+        return UIColor(red: r, green: g, blue: b, alpha: a)
+    }
+    #endif
 }


### PR DESCRIPTION
## Summary
- blend category colors with design system chip tokens to give selected chips a higher-contrast fill and outline
- pass the tinted fallback fill and stroke into the add-expense category pills so the non-glass rendering keeps the new outline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e14552e834832cbb7837fb08ae28ae