### PR TITLE
Clear add expense chip rows background

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -432,6 +432,15 @@ private struct CategoryChipsRow: View {
                 }
             }
         }
+        .listRowBackground(Color.clear)
+        .listRowInsets(
+            EdgeInsets(
+                top: DS.Spacing.s,
+                leading: DS.Spacing.l,
+                bottom: DS.Spacing.s,
+                trailing: DS.Spacing.l
+            )
+        )
         .sheet(isPresented: $isPresentingNewCategory) {
             ExpenseCategoryEditorSheet(
                 initialName: "",

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -295,6 +295,15 @@ private struct CategoryChipsRow: View {
             // Hide scroll indicators consistently across platforms
             .ub_hideScrollIndicators()
         }
+        .listRowBackground(Color.clear)
+        .listRowInsets(
+            EdgeInsets(
+                top: DS.Spacing.s,
+                leading: DS.Spacing.l,
+                bottom: DS.Spacing.s,
+                trailing: DS.Spacing.l
+            )
+        )
         .sheet(isPresented: $isPresentingNewCategory) {
             // Build as a single expression to avoid opaque 'some View' type mismatches.
             let base = ExpenseCategoryEditorSheet(


### PR DESCRIPTION
## Summary
- clear the category chip rows in both add expense sheets so they bypass the list background
- align their list row insets with the surrounding design system spacing

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e149aaf77c832cb4f6663cd6181fe1