### PR TITLE
Refine category chip tint handling

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -522,8 +522,7 @@ private struct CategoryChip: View {
 
         let pill = CategoryChipPill(
             isSelected: isSelected,
-            selectionColor: isSelected ? (style.glassStroke?.color ?? categoryColor) : nil,
-            selectionLineWidth: style.glassStroke?.lineWidth ?? style.fallbackStroke.lineWidth,
+            glassTint: style.glassTint,
             glassTextColor: style.glassTextColor,
             fallbackTextColor: style.fallbackTextColor,
             fallbackFill: style.fallbackFill,
@@ -584,7 +583,6 @@ private struct AddCategoryPillStyle: ButtonStyle {
 
         return CategoryChipPill(
             isSelected: false,
-            selectionColor: nil,
             glassTextColor: .primary,
             fallbackTextColor: .primary,
             fallbackFill: DS.Colors.chipFill,

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -388,8 +388,7 @@ private struct CategoryChip: View {
 
         let pill = CategoryChipPill(
             isSelected: isSelected,
-            selectionColor: isSelected ? (style.glassStroke?.color ?? categoryColor) : nil,
-            selectionLineWidth: style.glassStroke?.lineWidth ?? style.fallbackStroke.lineWidth,
+            glassTint: style.glassTint,
             glassTextColor: style.glassTextColor,
             fallbackTextColor: style.fallbackTextColor,
             fallbackFill: style.fallbackFill,
@@ -450,7 +449,6 @@ private struct AddCategoryPillStyle: ButtonStyle {
 
         return CategoryChipPill(
             isSelected: false,
-            selectionColor: nil,
             glassTextColor: .primary,
             fallbackTextColor: .primary,
             fallbackFill: DS.Colors.chipFill,

--- a/OffshoreBudgeting/Views/CategoryChipStyle.swift
+++ b/OffshoreBudgeting/Views/CategoryChipStyle.swift
@@ -14,7 +14,7 @@ struct CategoryChipStyle {
     let fallbackFill: Color
     let fallbackStroke: Stroke
     let glassTextColor: Color
-    let glassStroke: Stroke?
+    let glassTint: Color?
     let shadowColor: Color
     let shadowRadius: CGFloat
     let shadowY: CGFloat
@@ -33,7 +33,7 @@ struct CategoryChipStyle {
                 fallbackFill: DS.Colors.chipFill,
                 fallbackStroke: neutralStroke,
                 glassTextColor: .primary,
-                glassStroke: nil,
+                glassTint: nil,
                 shadowColor: .clear,
                 shadowRadius: 0,
                 shadowY: 0
@@ -48,27 +48,21 @@ struct CategoryChipStyle {
             fallbackOpacity: 0.22
         )
 
-        let selectionStroke: Color
-        let selectedLineWidth: CGFloat = 2.75
-        #if canImport(UIKit)
-        if #available(iOS 14.0, macCatalyst 14.0, *) {
-            let traitCollection = UITraitCollection(userInterfaceStyle: colorScheme == .dark ? .dark : .light)
-            let resolvedColor = UIColor(categoryColor).resolvedColor(with: traitCollection)
-            selectionStroke = Color(uiColor: resolvedColor)
-        } else {
-            selectionStroke = categoryColor
-        }
-        #else
-        selectionStroke = categoryColor
-        #endif
+        let selectionGlassTint = tintedColor(
+            baseNeutral: DS.Colors.chipSelectedFill,
+            accent: categoryColor,
+            fraction: 0.6,
+            colorScheme: colorScheme,
+            fallbackOpacity: 0.28
+        )
 
         return CategoryChipStyle(
             scale: 1.0,
             fallbackTextColor: .primary,
             fallbackFill: selectionFill,
-            fallbackStroke: Stroke(color: selectionStroke, lineWidth: selectedLineWidth),
+            fallbackStroke: neutralStroke,
             glassTextColor: .primary,
-            glassStroke: Stroke(color: selectionStroke, lineWidth: selectedLineWidth),
+            glassTint: selectionGlassTint,
             shadowColor: .clear,
             shadowRadius: 0,
             shadowY: 0

--- a/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
+++ b/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
@@ -12,8 +12,7 @@ struct CategoryChipPill<Label: View>: View {
     private var capsule: Capsule { Capsule(style: .continuous) }
 
     let isSelected: Bool
-    let selectionColor: Color?
-    let selectionLineWidth: CGFloat
+    let glassTint: Color?
     let glassTextColor: Color
     let fallbackTextColor: Color
     let fallbackFill: Color
@@ -25,8 +24,7 @@ struct CategoryChipPill<Label: View>: View {
 
     init(
         isSelected: Bool,
-        selectionColor: Color? = nil,
-        selectionLineWidth: CGFloat = 2,
+        glassTint: Color? = nil,
         glassTextColor: Color = .primary,
         fallbackTextColor: Color = .primary,
         fallbackFill: Color = DS.Colors.chipFill,
@@ -35,8 +33,7 @@ struct CategoryChipPill<Label: View>: View {
         @ViewBuilder label: @escaping () -> Label
     ) {
         self.isSelected = isSelected
-        self.selectionColor = selectionColor
-        self.selectionLineWidth = selectionLineWidth
+        self.glassTint = glassTint
         self.glassTextColor = glassTextColor
         self.fallbackTextColor = fallbackTextColor
         self.fallbackFill = fallbackFill
@@ -48,9 +45,15 @@ struct CategoryChipPill<Label: View>: View {
     var body: some View {
         Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
-                baseLabel
-                    .foregroundStyle(glassTextColor)
-                    .glassEffect(.regular, in: capsule)
+                if isSelected, let glassTint {
+                    baseLabel
+                        .foregroundStyle(glassTextColor)
+                        .glassEffect(.regular.tint(glassTint).interactive(), in: capsule)
+                } else {
+                    baseLabel
+                        .foregroundStyle(glassTextColor)
+                        .glassEffect(.regular, in: capsule)
+                }
             } else {
                 baseLabel
                     .foregroundStyle(fallbackTextColor)
@@ -65,11 +68,6 @@ struct CategoryChipPill<Label: View>: View {
                             )
                         }
                     }
-            }
-        }
-        .overlay {
-            if isSelected, let selectionColor {
-                capsule.strokeBorder(selectionColor, lineWidth: selectionLineWidth)
             }
         }
         .frame(height: controlHeight)
@@ -118,7 +116,6 @@ struct CategoryTotalsRow: View {
                 ForEach(categories) { cat in
                     let pill = CategoryChipPill(
                         isSelected: false,
-                        selectionColor: nil,
                         glassTextColor: .primary,
                         fallbackTextColor: .primary,
                         fallbackFill: DS.Colors.chipFill,


### PR DESCRIPTION
## Summary
- add a derived glass tint to `CategoryChipStyle` and remove the selection stroke overlay
- update `CategoryChipPill` to use the optional tint when applying the glass effect and streamline the fallback styling
- pass the new tint through the planned and unplanned expense chip builders while cleaning up unused selection border parameters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1592578cc832c801f6379be659b09