### PR TITLE
Improve card loading handling on expense sheets

### DIFF
--- a/OffshoreBudgeting/View Models/AddPlannedExpenseViewModel.swift
+++ b/OffshoreBudgeting/View Models/AddPlannedExpenseViewModel.swift
@@ -28,6 +28,7 @@ final class AddPlannedExpenseViewModel: ObservableObject {
     @Published private(set) var allBudgets: [Budget] = []
     @Published private(set) var allCategories: [ExpenseCategory] = []
     @Published private(set) var allCards: [Card] = []
+    @Published private(set) var cardsLoaded = false
 
     // MARK: Live Updates
     /// Listens for Core Data changes and reloads cards/categories/budgets on demand.
@@ -63,6 +64,7 @@ final class AddPlannedExpenseViewModel: ObservableObject {
 
     // MARK: load()
     func load() async {
+        cardsLoaded = false
         CoreDataService.shared.ensureLoaded()
         allBudgets = fetchBudgets()
         allCategories = fetchCategories()
@@ -103,8 +105,11 @@ final class AddPlannedExpenseViewModel: ObservableObject {
                 self.allCards = self.fetchCards()
                 self.allCategories = self.fetchCategories()
                 self.allBudgets = self.fetchBudgets()
+                self.cardsLoaded = true
             }
         }
+
+        cardsLoaded = true
     }
 
     // MARK: Validation

--- a/OffshoreBudgeting/View Models/AddUnplannedExpenseViewModel.swift
+++ b/OffshoreBudgeting/View Models/AddUnplannedExpenseViewModel.swift
@@ -22,6 +22,7 @@ final class AddUnplannedExpenseViewModel: ObservableObject {
 
     // MARK: Loaded Data
     @Published private(set) var allCards: [Card] = []
+    @Published private(set) var cardsLoaded = false
     @Published private(set) var allCategories: [ExpenseCategory] = []
 
     // MARK: Allowed filter (e.g., only cards tracked by a given budget)
@@ -57,6 +58,7 @@ final class AddUnplannedExpenseViewModel: ObservableObject {
 
     // MARK: load()
     func load() async {
+        cardsLoaded = false
         await CoreDataService.shared.waitUntilStoresLoaded()
         reloadLists()
 
@@ -183,6 +185,7 @@ final class AddUnplannedExpenseViewModel: ObservableObject {
 
         allCards = fetchCards()
         allCategories = fetchCategories()
+        cardsLoaded = true
 
         guard preserveSelection else { return }
 

--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -90,7 +90,11 @@ struct AddPlannedExpenseView: View {
         ) {
             // MARK: Card Selection
             UBFormSection("Card", isUppercased: true) {
-                if vm.allCards.isEmpty {
+                if !vm.cardsLoaded {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                        .frame(height: cardRowHeight)
+                } else if vm.allCards.isEmpty {
                     VStack(spacing: DS.Spacing.m) {
                         Text("No cards yet. Add one to assign this expense.")
                             .foregroundStyle(.secondary)

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -66,7 +66,11 @@ struct AddUnplannedExpenseView: View {
         ) {
             // MARK: Card Picker (horizontal)
             UBFormSection("Assign a Card to Expense", isUppercased: false) {
-                if vm.allCards.isEmpty {
+                if !vm.cardsLoaded {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                        .frame(height: cardRowHeight)
+                } else if vm.allCards.isEmpty {
                     VStack(spacing: DS.Spacing.m) {
                         Text("No cards yet. Add one to assign this expense.")
                             .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- add a cardsLoaded flag to the planned and unplanned expense view models
- show a progress indicator while cards load and only present the empty-state once data is available

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e15f06f9dc832cab9b78340a80199d