### PR TITLE
Fix Liquid Glass CTA capability detection

### DIFF
--- a/OffshoreBudgeting/Systems/PlatformCapabilities.swift
+++ b/OffshoreBudgeting/Systems/PlatformCapabilities.swift
@@ -101,6 +101,39 @@ extension PlatformCapabilities {
 
 // MARK: - Environment support
 
+extension PlatformCapabilities {
+    /// Verifies the OS 26 translucent toggle is enabled for the supplied
+    /// component. When we detect a modern OS but the capability evaluates to
+    /// `false`, log the mismatch and return a corrected copy so downstream
+    /// views can still opt into Liquid Glass.
+    ///
+    /// Temporary instrumentation while we chase down remaining call sites that
+    /// might be missing the shared capability environment injection.
+    func correctingForLiquidGlassIfNeeded(component: String) -> PlatformCapabilities {
+        if supportsOS26Translucency {
+            AppLog.ui.info(
+                "LiquidGlassDiagnostics component=\(component, privacy: .public) supportsOS26Translucency=true"
+            )
+            return self
+        }
+
+        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            AppLog.ui.error(
+                "LiquidGlassDiagnostics component=\(component, privacy: .public) supportsOS26Translucency=false overriding=true"
+            )
+            return PlatformCapabilities(
+                supportsOS26Translucency: true,
+                supportsAdaptiveKeypad: supportsAdaptiveKeypad
+            )
+        }
+
+        AppLog.ui.info(
+            "LiquidGlassDiagnostics component=\(component, privacy: .public) supportsOS26Translucency=false (legacy path)"
+        )
+        return self
+    }
+}
+
 private struct PlatformCapabilitiesKey: EnvironmentKey {
     static let defaultValue: PlatformCapabilities = .fallback
 }

--- a/OffshoreBudgeting/Views/Components/GlassCTAButton.swift
+++ b/OffshoreBudgeting/Views/Components/GlassCTAButton.swift
@@ -32,9 +32,15 @@ struct GlassCTAButton<Label: View>: View {
         self.fallbackMetrics = fallbackMetrics
     }
 
+    private var correctedCapabilities: PlatformCapabilities {
+        capabilities.correctingForLiquidGlassIfNeeded(component: "GlassCTAButton")
+    }
+
     var body: some View {
-        Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+        let localCapabilities = correctedCapabilities
+
+        return Group {
+            if localCapabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
 #if DEBUG && LIQUID_GLASS_QA
                 capabilities.qaLogLiquidGlassDecision(component: "GlassCTAButton", path: "glass")
 #endif
@@ -47,6 +53,7 @@ struct GlassCTAButton<Label: View>: View {
             }
         }
         .frame(maxWidth: resolvedMaxWidth)
+        .environment(\.platformCapabilities, localCapabilities)
     }
 
     // MARK: - Private Helpers
@@ -67,16 +74,21 @@ struct GlassCTAButton<Label: View>: View {
     @available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *)
     @ViewBuilder
     private func glassButton() -> some View {
-        Button(action: action) {
-            labelBuilder()
-                .font(.system(size: 17, weight: .semibold, design: .rounded))
-                .foregroundStyle(glassLabelForeground)
-                .padding(.horizontal, DS.Spacing.xl)
-                .padding(.vertical, DS.Spacing.m)
-                .frame(maxWidth: fillHorizontally ? .infinity : nil, alignment: .center)
+        let capsule = Capsule(style: .continuous)
+
+        GlassEffectContainer {
+            Button(action: action) {
+                labelBuilder()
+                    .font(.system(size: 17, weight: .semibold, design: .rounded))
+                    .foregroundStyle(glassLabelForeground)
+                    .padding(.horizontal, DS.Spacing.xl)
+                    .padding(.vertical, DS.Spacing.m)
+            }
+            .frame(maxWidth: fillHorizontally ? .infinity : nil, alignment: .center)
+            .buttonStyle(.glass)
+            .tint(glassTint)
+            .glassEffect(.regular.tint(glassTint).interactive(), in: capsule)
         }
-        .buttonStyle(.glass)
-        .tint(glassTint)
     }
 
     private var fallbackTint: Color {


### PR DESCRIPTION
## Summary
- add a reusable PlatformCapabilities helper that logs and corrects Liquid Glass support when the OS is new enough
- update GlassCTAButton and UBEmptyState to consume the corrected capabilities and share the value with their subviews
- wrap OS 26+ CTA buttons in GlassEffectContainer and apply glassEffect for harmonized Liquid Glass rendering

## Testing
- not run (Catalyst build)


------
https://chatgpt.com/codex/tasks/task_e_68e1841b7820832cbbbc45be037e8397