### PR TITLE
Handle legacy Catalyst toolbar chrome in edit sheets

### DIFF
--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -48,6 +48,7 @@ struct EditSheetScaffold<Content: View>: View {
 
     // MARK: Environment
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.platformCapabilities) private var platformCapabilities
     @EnvironmentObject private var themeManager: ThemeManager
 
     // Selection state for detents (compat type)
@@ -79,37 +80,29 @@ struct EditSheetScaffold<Content: View>: View {
 
     // MARK: body
     var body: some View {
-        navigationContainer {
-            formContent
-                .navigationTitle(title)
-                .toolbar {
-                    // Cancel
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button(cancelButtonTitle) {
-                            onCancel?()
-                            dismiss()
+        applySheetChrome(
+            to: navigationContainer {
+                formContent
+                    .navigationTitle(title)
+                    .toolbar {
+                        // Cancel
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button(cancelButtonTitle) {
+                                onCancel?()
+                                dismiss()
+                            }
+                            .tint(themeManager.selectedTheme.resolvedTint)
                         }
-                        .tint(themeManager.selectedTheme.resolvedTint)
-                    }
-                    // Save
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button(saveButtonTitle) {
-                            if onSave() { dismiss() }
+                        // Save
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button(saveButtonTitle) {
+                                if onSave() { dismiss() }
+                            }
+                            .tint(themeManager.selectedTheme.resolvedTint)
+                            .disabled(!isSaveEnabled)
                         }
-                        .tint(themeManager.selectedTheme.resolvedTint)
-                        .disabled(!isSaveEnabled)
                     }
-                }
-        }
-        .ub_navigationBackground(
-            theme: themeManager.selectedTheme,
-            configuration: themeManager.glassConfiguration
-        )
-        .accentColor(themeManager.selectedTheme.resolvedTint)
-        .tint(themeManager.selectedTheme.resolvedTint)
-        .ub_surfaceBackground(
-            themeManager.selectedTheme,
-            configuration: themeManager.glassConfiguration
+            }
         )
         // MARK: Standard sheet behavior (platform-aware)
         .applyDetentsIfAvailable(detents: detents, selection: detentSelectionBinding)
@@ -170,6 +163,54 @@ struct EditSheetScaffold<Content: View>: View {
 
     // MARK: Detent selection binding (iOS only)
     private var detentSelectionBinding: Binding<UBPresentationDetent>? { $detentSelection }
+
+    // MARK: - Chrome styling
+    private func applySheetChrome<Inner: View>(to view: Inner) -> some View {
+        view.modifier(
+            EditSheetChromeModifier(
+                theme: themeManager.selectedTheme,
+                glassConfiguration: themeManager.glassConfiguration,
+                platformCapabilities: platformCapabilities
+            )
+        )
+    }
+
+    private struct EditSheetChromeModifier: ViewModifier {
+        let theme: AppTheme
+        let glassConfiguration: AppTheme.GlassConfiguration
+        let platformCapabilities: PlatformCapabilities
+
+        @ViewBuilder
+        func body(content: Content) -> some View {
+            let styledContent = content
+                .accentColor(theme.resolvedTint)
+                .tint(theme.resolvedTint)
+                .ub_surfaceBackground(
+                    theme,
+                    configuration: glassConfiguration
+                )
+
+#if targetEnvironment(macCatalyst)
+            if platformCapabilities.supportsOS26Translucency {
+                styledContent
+                    .ub_navigationBackground(
+                        theme: theme,
+                        configuration: glassConfiguration
+                    )
+            } else {
+                styledContent
+                    .toolbarBackground(.visible, for: .navigationBar)
+                    .toolbarBackground(.clear, for: .navigationBar)
+            }
+#else
+            styledContent
+                .ub_navigationBackground(
+                    theme: theme,
+                    configuration: glassConfiguration
+                )
+#endif
+        }
+    }
 }
 
 // MARK: - Detents application helper


### PR DESCRIPTION
## Summary
- inject the platformCapabilities environment into the edit sheet scaffold
- centralize the sheet chrome styling behind a reusable helper
- fall back to clear toolbar backgrounds on Catalyst runtimes that lack OS26 translucency while keeping the glass path for others

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e19b798d68832c94378d00f85ffaf7