### PR TITLE
Fix Mac Catalyst toolbar availability guard

### DIFF
--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -198,9 +198,17 @@ struct EditSheetScaffold<Content: View>: View {
                         configuration: glassConfiguration
                     )
             } else {
-                styledContent
-                    .toolbarBackground(.visible, for: .navigationBar)
-                    .toolbarBackground(.clear, for: .navigationBar)
+                if #available(iOS 16.0, macCatalyst 16.0, *) {
+                    styledContent
+                        .toolbarBackground(.visible, for: .navigationBar)
+                        .toolbarBackground(.clear, for: .navigationBar)
+                } else {
+                    styledContent
+                        .ub_navigationBackground(
+                            theme: theme,
+                            configuration: glassConfiguration
+                        )
+                }
             }
 #else
             styledContent


### PR DESCRIPTION
## Summary
- guard Catalyst toolbar background customization with platform availability checks
- fall back to the shared navigation background helper when targeting pre-macOS 13 Catalyst builds

## Testing
- xcodebuild -project OffshoreBudgeting.xcodeproj -scheme OffshoreBudgeting -destination 'platform=iOS Simulator,name=iPhone 15' build *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1affe2008832c970f0802ae9c2519