### PR TITLE
Refine system theme capability handling

### DIFF
--- a/OffshoreBudgeting/OffshoreBudgetingApp.swift
+++ b/OffshoreBudgeting/OffshoreBudgetingApp.swift
@@ -89,14 +89,26 @@ struct OffshoreBudgetingApp: App {
             .modifier(ThemedToggleTint(color: themeManager.selectedTheme.toggleTint))
             .onAppear {
                 themeManager.refreshSystemAppearance(systemColorScheme)
-                SystemThemeAdapter.applyGlobalChrome(theme: themeManager.selectedTheme, colorScheme: systemColorScheme)
+                SystemThemeAdapter.applyGlobalChrome(
+                    theme: themeManager.selectedTheme,
+                    colorScheme: systemColorScheme,
+                    platformCapabilities: platformCapabilities
+                )
             }
             .ub_onChange(of: systemColorScheme) { newScheme in
                 themeManager.refreshSystemAppearance(newScheme)
-                SystemThemeAdapter.applyGlobalChrome(theme: themeManager.selectedTheme, colorScheme: newScheme)
+                SystemThemeAdapter.applyGlobalChrome(
+                    theme: themeManager.selectedTheme,
+                    colorScheme: newScheme,
+                    platformCapabilities: platformCapabilities
+                )
             }
             .ub_onChange(of: themeManager.selectedTheme) {
-                SystemThemeAdapter.applyGlobalChrome(theme: themeManager.selectedTheme, colorScheme: systemColorScheme)
+                SystemThemeAdapter.applyGlobalChrome(
+                    theme: themeManager.selectedTheme,
+                    colorScheme: systemColorScheme,
+                    platformCapabilities: platformCapabilities
+                )
             }
     }
 

--- a/OffshoreBudgeting/Systems/SystemTheme.swift
+++ b/OffshoreBudgeting/Systems/SystemTheme.swift
@@ -7,23 +7,26 @@ import UIKit
 enum SystemThemeAdapter {
     enum Flavor { case liquid, classic }
 
-    static var currentFlavor: Flavor {
-        // Treat OS 26 as the threshold for the native Liquid Glass cycle.
-        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-            return .liquid
-        } else {
-            return .classic
-        }
+    static var currentFlavor: Flavor { flavor() }
+
+    static func flavor(for capabilities: PlatformCapabilities = .current) -> Flavor {
+        capabilities.supportsOS26Translucency ? .liquid : .classic
     }
 
     /// Apply minimal, system-friendly global chrome. On OS 26 we avoid
     /// overriding system appearances per Apple guidance. On earlier OS versions,
     /// we set plain, opaque backgrounds to respect the classic, flat style.
-    static func applyGlobalChrome(theme: AppTheme, colorScheme: ColorScheme?) {
+    /// The supplied `platformCapabilities` snapshot ensures every scene makes
+    /// the same chrome decision without re-evaluating availability checks.
+    static func applyGlobalChrome(
+        theme: AppTheme,
+        colorScheme: ColorScheme?,
+        platformCapabilities: PlatformCapabilities = .current
+    ) {
         // Always prefer large titles so OS26 shows the big title on initial load.
         UINavigationBar.appearance().prefersLargeTitles = true
 
-        guard currentFlavor == .classic else { return }
+        guard !platformCapabilities.supportsOS26Translucency else { return }
 
         // UINavigationBar
         let navAppearance = UINavigationBarAppearance()

--- a/OffshoreBudgetingTests/SystemThemeAdapterTests.swift
+++ b/OffshoreBudgetingTests/SystemThemeAdapterTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import Offshore
+
+struct SystemThemeAdapterTests {
+
+    @Test
+    func flavor_prefersLiquidGlassWhenTranslucencySupported() {
+        let capabilities = PlatformCapabilities(
+            supportsOS26Translucency: true,
+            supportsAdaptiveKeypad: true
+        )
+
+        #expect(SystemThemeAdapter.flavor(for: capabilities) == .liquid)
+    }
+
+    @Test
+    func flavor_fallsBackToClassicWhenTranslucencyUnavailable() {
+        let capabilities = PlatformCapabilities(
+            supportsOS26Translucency: false,
+            supportsAdaptiveKeypad: false
+        )
+
+        #expect(SystemThemeAdapter.flavor(for: capabilities) == .classic)
+    }
+}


### PR DESCRIPTION
## Summary
- drive the system theme flavor selection from a shared `PlatformCapabilities` snapshot
- ensure classic chrome customization only runs when OS 26 translucency is unavailable
- add focused unit coverage for the flavor helper

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1b3b9d248832c9110d9feb3669b3c