### PR TITLE
Ensure legacy home header padding matches default inset

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -1042,7 +1042,10 @@ private enum HomeHeaderOverviewMetrics {
             return RootTabHeaderLayout.defaultHorizontalPadding
         }
 
-        return max(layoutContext.safeArea.leading, 0)
+        return max(
+            layoutContext.safeArea.leading,
+            RootTabHeaderLayout.defaultHorizontalPadding
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure Home header overview metrics keep default horizontal padding on legacy safe-area fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b7de83f4832cb00819fb23bc6776