### PR TITLE
Adjust home header padding fallback for legacy compact layouts

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -1042,7 +1042,21 @@ private enum HomeHeaderOverviewMetrics {
             return RootTabHeaderLayout.defaultHorizontalPadding
         }
 
-        return max(layoutContext.safeArea.leading, 0)
+        if let safeAreaInset = legacySafeAreaHorizontalInset(from: layoutContext.safeArea) {
+            return safeAreaInset
+        }
+
+        return RootTabHeaderLayout.defaultHorizontalPadding
+    }
+
+    private static func legacySafeAreaHorizontalInset(from safeArea: EdgeInsets) -> CGFloat? {
+        let leadingInset = max(safeArea.leading, 0)
+        if leadingInset > 0 { return leadingInset }
+
+        let trailingInset = max(safeArea.trailing, 0)
+        if trailingInset > 0 { return trailingInset }
+
+        return nil
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the home header uses the default horizontal padding on legacy compact devices without safe-area insets
- add a helper that reuses any available safe-area inset before falling back to the default spacing

## Testing
- not run (requires iOS simulators)

------
https://chatgpt.com/codex/tasks/task_e_68e1b8d9a418832c98d76f2b562d3c2e