### PR TITLE
Fix legacy padding fallbacks for Home and Budget views

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -1606,10 +1606,16 @@ private enum BudgetListHorizontalPaddingMetrics {
 
         let safeArea = layoutContext.safeArea
         if safeArea.hasNonZeroInsets {
-            return Insets(leading: safeArea.leading, trailing: safeArea.trailing)
+            let leading = safeArea.leading > 0 ? safeArea.leading : RootTabHeaderLayout.defaultHorizontalPadding
+            let trailing = safeArea.trailing > 0 ? safeArea.trailing : RootTabHeaderLayout.defaultHorizontalPadding
+
+            return Insets(leading: leading, trailing: trailing)
         }
 
-        return Insets(leading: 0, trailing: 0)
+        return Insets(
+            leading: RootTabHeaderLayout.defaultHorizontalPadding,
+            trailing: RootTabHeaderLayout.defaultHorizontalPadding
+        )
     }
 }
 

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -1042,7 +1042,12 @@ private enum HomeHeaderOverviewMetrics {
             return RootTabHeaderLayout.defaultHorizontalPadding
         }
 
-        return max(layoutContext.safeArea.leading, 0)
+        let safeAreaInset = max(layoutContext.safeArea.leading, 0)
+        if safeAreaInset > 0 {
+            return safeAreaInset
+        }
+
+        return RootTabHeaderLayout.defaultHorizontalPadding
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the Home header overview enforces the default horizontal padding when legacy safe-area insets are empty
- align budget list horizontal inset resolution with the same fallback so empty and loaded states remain consistent on legacy OSes

## Testing
- not run (iOS simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1b9e81a74832c91e2b21812abfcb7