### PR TITLE
Enable interaction for home category chips

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -823,7 +823,6 @@ private struct HomeHeaderOverviewTable: View {
                 CategoryTotalsRow(
                     categories: categorySpending,
                     isPlaceholder: false,
-                    isInteractive: false,
                     horizontalInset: 0
                 )
                 .frame(height: HomeHeaderOverviewMetrics.categoryControlHeight)
@@ -832,7 +831,6 @@ private struct HomeHeaderOverviewTable: View {
                 CategoryTotalsRow(
                     categories: globalCategorySpending,
                     isPlaceholder: false,
-                    isInteractive: false,
                     horizontalInset: 0
                 )
                 .frame(height: HomeHeaderOverviewMetrics.categoryControlHeight)


### PR DESCRIPTION
## Summary
- allow category totals chips in the home header to be interactive again by removing the explicit non-interactive flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2730a4f10832ca3058085b028f436