### PR TITLE
Disable horizontal bounce for chip carousels

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -497,6 +497,7 @@ private extension CategoryChipsRow {
             .padding(.horizontal, DS.Spacing.s)
         }
         .ub_hideScrollIndicators()
+        .ub_disableHorizontalBounce()
         .clipped()
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -360,6 +360,7 @@ private extension CategoryChipsRow {
             .padding(.horizontal, DS.Spacing.s)
         }
         .ub_hideScrollIndicators()
+        .ub_disableHorizontalBounce()
         .clipped()
         .frame(maxWidth: .infinity, alignment: .leading)
     }


### PR DESCRIPTION
## Summary
- add a compatibility helper that disables horizontal bounce on embedded UIScrollViews
- apply the helper to the planned and unplanned expense chip carousels so they stay clipped alongside the Add button

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e27dff01f8832c92c8fec39c24050f