### PR TITLE
Fix expense category cascade relationships

### DIFF
--- a/OffshoreBudgeting/OffshoreBudgetingModel.xcdatamodeld/OffshoreBudgetingModel.xcdatamodel/contents
+++ b/OffshoreBudgeting/OffshoreBudgetingModel.xcdatamodeld/OffshoreBudgetingModel.xcdatamodel/contents
@@ -47,7 +47,7 @@
         <attribute name="transactionDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="budget" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Budget" inverseName="plannedExpense" inverseEntity="Budget"/>
         <relationship name="card" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Card" inverseName="plannedExpenses" inverseEntity="Card"/>
-        <relationship name="expenseCategory" maxCount="1" deletionRule="Cascade" destinationEntity="ExpenseCategory" inverseName="plannedExpense" inverseEntity="ExpenseCategory"/>
+        <relationship name="expenseCategory" maxCount="1" deletionRule="Nullify" destinationEntity="ExpenseCategory" inverseName="plannedExpense" inverseEntity="ExpenseCategory"/>
     </entity>
     <entity name="UnplannedExpense" representedClassName="UnplannedExpense" syncable="YES" codeGenerationType="class">
         <attribute name="amount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
@@ -60,7 +60,7 @@
         <attribute name="transactionDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="card" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Card" inverseName="unplannedExpenses" inverseEntity="Card"/>
         <relationship name="childExpense" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="UnplannedExpense" inverseName="parentExpense" inverseEntity="UnplannedExpense"/>
-        <relationship name="expenseCategory" maxCount="1" deletionRule="Cascade" destinationEntity="ExpenseCategory" inverseName="unplannedExpense" inverseEntity="ExpenseCategory"/>
+        <relationship name="expenseCategory" maxCount="1" deletionRule="Nullify" destinationEntity="ExpenseCategory" inverseName="unplannedExpense" inverseEntity="ExpenseCategory"/>
         <relationship name="parentExpense" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UnplannedExpense" inverseName="childExpense" inverseEntity="UnplannedExpense"/>
     </entity>
 </model>


### PR DESCRIPTION
## Summary
- ensure the ExpenseCategory to planned/unplanned expense relationships cascade down so deleting a category removes its expenses
- switch the inverse relationships on PlannedExpense and UnplannedExpense to Nullify to prevent child deletions from removing the parent category

## Testing
- not run (iOS simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e28600ba60832c9721af1d3b129945