### PR TITLE
Ensure landscape calendar matches selected day height

### DIFF
--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -286,6 +286,7 @@ struct IncomeView: View {
                     HStack(alignment: .top, spacing: columnSpacing) {
                         calendarSection(using: proxy, cardHeight: calendarCardHeight)
                             .frame(width: calendarWidth, alignment: .top)
+                            .frame(height: sharedTargetHeight, alignment: .top)
 
                         selectedDaySection(minHeight: minimums.selected)
                             .frame(maxWidth: .infinity, alignment: .top)
@@ -301,6 +302,7 @@ struct IncomeView: View {
                 HStack(alignment: .top, spacing: columnSpacing) {
                     calendarSection(using: proxy, cardHeight: calendarCardHeight)
                         .frame(width: calendarWidth, alignment: .top)
+                        .frame(height: sharedTargetHeight, alignment: .top)
 
                     VStack(spacing: DS.Spacing.m) {
                         selectedDaySection(minHeight: minimums.selected)


### PR DESCRIPTION
## Summary
- align the landscape calendar card frame height with the selected-day column so both columns share the same height

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e287132f68832c9be512e07a142665