### PR TITLE
Align landscape calendar height with selected day

### DIFF
--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -286,6 +286,7 @@ struct IncomeView: View {
                     HStack(alignment: .top, spacing: columnSpacing) {
                         calendarSection(using: proxy, cardHeight: calendarCardHeight)
                             .frame(width: calendarWidth, alignment: .top)
+                            .frame(height: sharedTargetHeight, alignment: .top)
 
                         selectedDaySection(minHeight: minimums.selected)
                             .frame(maxWidth: .infinity, alignment: .top)
@@ -301,6 +302,7 @@ struct IncomeView: View {
                 HStack(alignment: .top, spacing: columnSpacing) {
                     calendarSection(using: proxy, cardHeight: calendarCardHeight)
                         .frame(width: calendarWidth, alignment: .top)
+                        .frame(height: sharedTargetHeight, alignment: .top)
 
                     VStack(spacing: DS.Spacing.m) {
                         selectedDaySection(minHeight: minimums.selected)


### PR DESCRIPTION
## Summary
- ensure the landscape calendar column is constrained to the shared target height so it stays aligned with the selected-day column

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2894ed888832cbe606879ad91bc1b