### PR TITLE
Ensure IncomeView calendar scroll persists through layout changes

### DIFF
--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -144,6 +144,7 @@ struct IncomeView: View {
     }
 
     private let calendarSectionContentPadding: CGFloat = 10
+    private let calendarScrollResetDelay: DispatchTimeInterval = .milliseconds(150)
 
     private func calendarChromeHeight() -> CGFloat {
         navigationButtonRowHeight + CalendarSectionMetrics.headerSpacing + (calendarSectionContentPadding * 2)
@@ -512,7 +513,7 @@ struct IncomeView: View {
                     .monthLabel(UBMonthLabel.init)
                     .startMonth(start)
                     .endMonth(end)
-                    .scrollTo(date: calendarScrollDate)
+                    .scrollTo(date: calendarScrollDate ?? viewModel.selectedDate)
             }
             .transaction { t in
                 t.animation = nil
@@ -704,7 +705,8 @@ struct IncomeView: View {
             calendarScrollDate = target
         }
         // Reset the scroll target on the next run loop cycle without animation
-        DispatchQueue.main.async {
+        DispatchQueue.main.asyncAfter(deadline: .now() + calendarScrollResetDelay) {
+            guard calendarScrollDate == target else { return }
             withTransaction(Transaction(animation: nil)) {
                 calendarScrollDate = nil
             }


### PR DESCRIPTION
## Summary
- update the income calendar scroll target to fall back to the current selection when no programmatic scroll date is provided
- delay clearing `calendarScrollDate` so the scroll request survives layout transitions such as rotation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e28b531e78832ca7028905f0badf70