### PR TITLE
Fix category chip pills rendering in expense forms

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -590,7 +590,7 @@ private struct CategoryChip: View {
                     .font(.subheadline.weight(.semibold))
             }
         }
-        let resolvedChip = Group {
+        Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
                 if let ns = namespace {
                     pill
@@ -602,25 +602,9 @@ private struct CategoryChip: View {
                 pill
             }
         }
-
-        let base = resolvedChip
-            .scaleEffect(style.scale)
-            .animation(.easeOut(duration: 0.15), value: isSelected)
-            .accessibilityAddTraits(isSelected ? .isSelected : [])
-
-        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
-
-//        if shouldApplyShadow {
-//            base
-//                .shadow(
-//                    color: style.shadowColor,
-//                    radius: style.shadowRadius,
-//                    x: 0,
-//                    y: style.shadowY
-//                )
-//        } else {
-//            base
-//        }
+        .scaleEffect(style.scale)
+        .animation(.easeOut(duration: 0.15), value: isSelected)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
 }

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -444,7 +444,7 @@ private struct CategoryChip: View {
                     .font(.subheadline.weight(.semibold))
             }
         }
-        let resolvedChip = Group {
+        Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macCatalyst 26.0, *) {
                 if let ns = namespace {
                     pill
@@ -456,25 +456,9 @@ private struct CategoryChip: View {
                 pill
             }
         }
-
-        let base = resolvedChip
-            .scaleEffect(style.scale)
-            .animation(.easeOut(duration: 0.15), value: isSelected)
-            .accessibilityAddTraits(isSelected ? .isSelected : [])
-
-        let shouldApplyShadow = style.shadowRadius > 0 || style.shadowY != 0
-
-//        if shouldApplyShadow {
-//            base
-//                .shadow(
-//                    color: style.shadowColor,
-//                    radius: style.shadowRadius,
-//                    x: 0,
-//                    y: style.shadowY
-//                )
-//        } else {
-//            base
-//        }
+        .scaleEffect(style.scale)
+        .animation(.easeOut(duration: 0.15), value: isSelected)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
 }


### PR DESCRIPTION
## Summary
- ensure AddPlannedExpenseView category chips return their configured pill content
- mirror the same fix for AddUnplannedExpenseView to render chips consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e28cd635ac832c9d6f709f105409d7