### PR TITLE
Fix category chip scroll clipping in expense forms

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -447,6 +447,7 @@ private extension CategoryChipsRow {
     private func chipRowLayout() -> some View {
         HStack(alignment: .center, spacing: DS.Spacing.s) {
             addCategoryButton
+                .zIndex(1)
             chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)
@@ -460,8 +461,8 @@ private extension CategoryChipsRow {
         }
         .ub_hideScrollIndicators()
         .ub_disableHorizontalBounce()
-        .clipped()
         .frame(maxWidth: .infinity, alignment: .leading)
+        .clipped()
     }
 
     @ViewBuilder

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -308,6 +308,7 @@ private extension CategoryChipsRow {
     private func chipRowLayout() -> some View {
         HStack(alignment: .center, spacing: DS.Spacing.s) {
             addCategoryButton
+                .zIndex(1)
             chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)
@@ -321,8 +322,8 @@ private extension CategoryChipsRow {
         }
         .ub_hideScrollIndicators()
         .ub_disableHorizontalBounce()
-        .clipped()
         .frame(maxWidth: .infinity, alignment: .leading)
+        .clipped()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- ensure the add-category pill stays above the scrolling chips in the planned expense form
- mirror the same layout adjustments in the unplanned expense form for consistency
- move the chip scroll view clipping after sizing so the chips respect their container bounds

## Testing
- `xcodebuild -project OffshoreBudgeting.xcodeproj -scheme OffshoreBudgeting -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' build` *(fails: `xcodebuild` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e299818ce0832c953adc77bce27073