### PR TITLE
Refine category chip rows to pin add pill

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -387,6 +387,7 @@ private struct CategoryChipsRow: View {
     private var categories: FetchedResults<ExpenseCategory>
 
     @State private var isPresentingNewCategory = false
+    @State private var addPillWidth: CGFloat = 0
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
     private let chipRowClipShape = Capsule(style: .continuous)
@@ -445,18 +446,24 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
+        ZStack(alignment: .leading) {
+            chipsScrollView()
+
             addCategoryButton
                 .zIndex(1)
-            chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onPreferenceChange(AddCategoryWidthPreferenceKey.self) { width in
+            guard addPillWidth != width else { return }
+            addPillWidth = width
+        }
     }
 
     private func chipsScrollView() -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             categoryChips
+                .padding(.leading, addPillWidth + DS.Spacing.s)
                 .padding(.trailing, DS.Spacing.s)
         }
         .ub_hideScrollIndicators()
@@ -489,6 +496,20 @@ private extension CategoryChipsRow {
 
     private var addCategoryButton: some View {
         AddCategoryPill { isPresentingNewCategory = true }
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(key: AddCategoryWidthPreferenceKey.self, value: proxy.size.width)
+                }
+            )
+    }
+}
+
+private struct AddCategoryWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -235,6 +235,7 @@ private struct CategoryChipsRow: View {
 
     // MARK: Local State
     @State private var isPresentingNewCategory = false
+    @State private var addPillWidth: CGFloat = 0
     @Environment(\.platformCapabilities) private var capabilities
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
@@ -306,18 +307,24 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
+        ZStack(alignment: .leading) {
+            chipsScrollView()
+
             addCategoryButton
                 .zIndex(1)
-            chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onPreferenceChange(AddCategoryWidthPreferenceKey.self) { width in
+            guard addPillWidth != width else { return }
+            addPillWidth = width
+        }
     }
 
     private func chipsScrollView() -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             categoryChips
+                .padding(.leading, addPillWidth + DS.Spacing.s)
                 .padding(.trailing, DS.Spacing.s)
         }
         .ub_hideScrollIndicators()
@@ -352,6 +359,20 @@ private extension CategoryChipsRow {
         AddCategoryPill {
             isPresentingNewCategory = true
         }
+        .background(
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(key: AddCategoryWidthPreferenceKey.self, value: proxy.size.width)
+            }
+        )
+    }
+}
+
+private struct AddCategoryWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 


### PR DESCRIPTION
## Summary
- capture the rendered width of the Add Category pill in the planned and unplanned expense chip rows
- overlay the fixed add pill atop a scrollable chip strip with dynamic leading padding so chips start to the right of the pill

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e29d73b734832c814eaf77a3c7fb94