### PR TITLE
Prevent category chips from overlapping Add pill

### DIFF
--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -235,10 +235,19 @@ private struct CategoryChipsRow: View {
 
     // MARK: Local State
     @State private var isPresentingNewCategory = false
+    @State private var addButtonWidth: CGFloat = 0
     @Environment(\.platformCapabilities) private var capabilities
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
     private let chipRowClipShape = Capsule(style: .continuous)
+
+    private struct AddButtonWidthPreferenceKey: PreferenceKey {
+        static var defaultValue: CGFloat = 0
+
+        static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+            value = max(value, nextValue())
+        }
+    }
 
     var body: some View {
         chipsScrollContainer()
@@ -306,13 +315,22 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
-            addCategoryButton
-                .zIndex(1)
+        ZStack(alignment: .leading) {
             chipsScrollView()
+                .padding(.horizontal, DS.Spacing.s)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, DS.Spacing.s)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .overlay(alignment: .leading) {
+            addCategoryButton
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear
+                            .preference(key: AddButtonWidthPreferenceKey.self, value: proxy.size.width)
+                    }
+                )
+                .padding(.leading, DS.Spacing.s)
+        }
+        .onPreferenceChange(AddButtonWidthPreferenceKey.self) { addButtonWidth = $0 }
     }
 
     private func chipsScrollView() -> some View {
@@ -329,6 +347,9 @@ private extension CategoryChipsRow {
     @ViewBuilder
     private var categoryChips: some View {
         LazyHStack(spacing: DS.Spacing.s) {
+            Color.clear
+                .frame(width: addButtonWidth + DS.Spacing.s)
+
             if categories.isEmpty {
                 Text("No categories yet")
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- measure the Add category pill in planned and unplanned expense chip rows and publish its width via a local preference key
- reserve a permanent leading gutter in the horizontal chip stacks and overlay the Add pill so the chips no longer slide underneath

## Testing
- Not run (simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2a0c23550832c92a320032c23e89a