### PR TITLE
Align category chip rows with add button spacing

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -387,6 +387,7 @@ private struct CategoryChipsRow: View {
     private var categories: FetchedResults<ExpenseCategory>
 
     @State private var isPresentingNewCategory = false
+    @State private var addButtonWidth: CGFloat = 0
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
     private let chipRowClipShape = Capsule(style: .continuous)
@@ -445,13 +446,16 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
-            addCategoryButton
-                .zIndex(1)
+        ZStack(alignment: .leading) {
             chipsScrollView()
+                .padding(.leading, addButtonWidth + DS.Spacing.s)
+            addCategoryButton
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onPreferenceChange(AddCategoryButtonWidthPreferenceKey.self) { width in
+            addButtonWidth = width
+        }
     }
 
     private func chipsScrollView() -> some View {
@@ -489,6 +493,20 @@ private extension CategoryChipsRow {
 
     private var addCategoryButton: some View {
         AddCategoryPill { isPresentingNewCategory = true }
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(key: AddCategoryButtonWidthPreferenceKey.self, value: proxy.size.width)
+                }
+            )
+    }
+}
+
+private enum AddCategoryButtonWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -235,6 +235,7 @@ private struct CategoryChipsRow: View {
 
     // MARK: Local State
     @State private var isPresentingNewCategory = false
+    @State private var addButtonWidth: CGFloat = 0
     @Environment(\.platformCapabilities) private var capabilities
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
@@ -306,13 +307,16 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
-            addCategoryButton
-                .zIndex(1)
+        ZStack(alignment: .leading) {
             chipsScrollView()
+                .padding(.leading, addButtonWidth + DS.Spacing.s)
+            addCategoryButton
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onPreferenceChange(AddCategoryButtonWidthPreferenceKey.self) { width in
+            addButtonWidth = width
+        }
     }
 
     private func chipsScrollView() -> some View {
@@ -352,6 +356,20 @@ private extension CategoryChipsRow {
         AddCategoryPill {
             isPresentingNewCategory = true
         }
+        .background(
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(key: AddCategoryButtonWidthPreferenceKey.self, value: proxy.size.width)
+            }
+        )
+    }
+}
+
+private enum AddCategoryButtonWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 


### PR DESCRIPTION
## Summary
- capture the add-category button width in the planned and unplanned expense forms
- offset the category chip scroll content so chips start to the right of the button while keeping glass styling
- remove the z-index workaround now that the chip rows have dedicated layout space

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a3fb5ebc832c9aa906004c5b794f