### PR TITLE
Keep add category pill fixed beside scrolling chips

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -445,10 +445,16 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
-            addCategoryButton
-                .zIndex(1)
-            chipsScrollView()
+        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+            HStack(spacing: DS.Spacing.s) {
+                addCategoryButton
+                    .zIndex(1)
+                Spacer(minLength: 0)
+            }
+
+            HStack(alignment: .center, spacing: 0) {
+                chipsScrollView()
+            }
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -306,10 +306,16 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
-            addCategoryButton
-                .zIndex(1)
-            chipsScrollView()
+        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+            HStack(spacing: DS.Spacing.s) {
+                addCategoryButton
+                    .zIndex(1)
+                Spacer(minLength: 0)
+            }
+
+            HStack(alignment: .center, spacing: 0) {
+                chipsScrollView()
+            }
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- stack the category chip row so the add pill sits above the scrolling chips in the planned expense form
- mirror the same vertical layout for the unplanned expense form to keep the UI consistent

## Testing
- `xcodebuild -project OffshoreBudgeting.xcodeproj -scheme OffshoreBudgeting -destination 'platform=iOS Simulator,name=iPhone 15' build` *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a6cb6c80832ca3f1b207e2ad41a9