### PR TITLE
Keep add category pill fixed next to chip scroller

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -445,16 +445,10 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
-            HStack(spacing: DS.Spacing.s) {
-                addCategoryButton
-                    .zIndex(1)
-                Spacer(minLength: 0)
-            }
-
-            HStack(alignment: .center, spacing: 0) {
-                chipsScrollView()
-            }
+        HStack(alignment: .center, spacing: DS.Spacing.s) {
+            addCategoryButton
+                .zIndex(1)
+            chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -306,16 +306,10 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
-            HStack(spacing: DS.Spacing.s) {
-                addCategoryButton
-                    .zIndex(1)
-                Spacer(minLength: 0)
-            }
-
-            HStack(alignment: .center, spacing: 0) {
-                chipsScrollView()
-            }
+        HStack(alignment: .center, spacing: DS.Spacing.s) {
+            addCategoryButton
+                .zIndex(1)
+            chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- update the planned expense category chip row to place the add button beside the horizontal scroller so it stays fixed
- mirror the same layout adjustment for the unplanned expense form to keep both experiences consistent

## Testing
- not run (UI flows require manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e2ab386e04832c9e423e158dc1bd63