### PR TITLE
Keep category add pill visible next to scrolling chips

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -447,6 +447,7 @@ private extension CategoryChipsRow {
     private func chipRowLayout() -> some View {
         HStack(alignment: .center, spacing: DS.Spacing.s) {
             addCategoryButton
+                .fixedSize(horizontal: true, vertical: false)
             chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -308,7 +308,7 @@ private extension CategoryChipsRow {
     private func chipRowLayout() -> some View {
         HStack(alignment: .center, spacing: DS.Spacing.s) {
             addCategoryButton
-                .zIndex(50)
+                .fixedSize(horizontal: true, vertical: false)
             chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)


### PR DESCRIPTION
## Summary
- ensure the planned expense chip row keeps the add button fixed ahead of the scrollable chips
- mirror the same fixed-pill and scrollable chips structure for unplanned expenses for consistent layout behavior

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2afa1b4d0832cbb11111898867056