### PR TITLE
Pin add category button above chip scrollers

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -387,6 +387,7 @@ private struct CategoryChipsRow: View {
     private var categories: FetchedResults<ExpenseCategory>
 
     @State private var isPresentingNewCategory = false
+    @State private var addCategoryButtonWidth: CGFloat = 0
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
     private let chipRowClipShape = Capsule(style: .continuous)
@@ -445,12 +446,16 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
-            addCategoryButton
+        ZStack(alignment: .leading) {
             chipsScrollView()
+                .padding(.leading, addCategoryButtonWidth + DS.Spacing.s)
+            addCategoryButton
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onPreferenceChange(AddCategoryButtonWidthPreferenceKey.self) { width in
+            addCategoryButtonWidth = width
+        }
     }
 
     private func chipsScrollView() -> some View {
@@ -488,6 +493,20 @@ private extension CategoryChipsRow {
 
     private var addCategoryButton: some View {
         AddCategoryPill { isPresentingNewCategory = true }
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(key: AddCategoryButtonWidthPreferenceKey.self, value: proxy.size.width)
+                }
+            )
+    }
+}
+
+private enum AddCategoryButtonWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat { 0 }
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -235,6 +235,7 @@ private struct CategoryChipsRow: View {
 
     // MARK: Local State
     @State private var isPresentingNewCategory = false
+    @State private var addCategoryButtonWidth: CGFloat = 0
     @Environment(\.platformCapabilities) private var capabilities
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
@@ -306,13 +307,17 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
+        ZStack(alignment: .leading) {
+            chipsScrollView()
+                .padding(.leading, addCategoryButtonWidth + DS.Spacing.s)
             addCategoryButton
                 .zIndex(50)
-            chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onPreferenceChange(AddCategoryButtonWidthPreferenceKey.self) { width in
+            addCategoryButtonWidth = width
+        }
     }
 
     private func chipsScrollView() -> some View {
@@ -352,6 +357,20 @@ private extension CategoryChipsRow {
         AddCategoryPill {
             isPresentingNewCategory = true
         }
+        .background(
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(key: AddCategoryButtonWidthPreferenceKey.self, value: proxy.size.width)
+            }
+        )
+    }
+}
+
+private enum AddCategoryButtonWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat { 0 }
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 


### PR DESCRIPTION
## Summary
- track the rendered width of the add-category pill in each expense form
- overlay the chips scroller with leading padding so chips never slide underneath the pinned button

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e2b11b15b8832cbbe378112bbfea7b