### PR TITLE
Reorder category chip controls in expense forms

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -445,8 +445,9 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
+        VStack(alignment: .leading, spacing: DS.Spacing.s) {
             addCategoryButton
+                .frame(maxWidth: .infinity, alignment: .center)
             chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -306,9 +306,9 @@ private extension CategoryChipsRow {
     }
 
     private func chipRowLayout() -> some View {
-        HStack(alignment: .center, spacing: DS.Spacing.s) {
+        VStack(alignment: .leading, spacing: DS.Spacing.s) {
             addCategoryButton
-                .zIndex(50)
+                .frame(maxWidth: .infinity, alignment: .center)
             chipsScrollView()
         }
         .padding(.horizontal, DS.Spacing.s)


### PR DESCRIPTION
## Summary
- stack the Add Category pill on its own row above the chip scroller in the planned expense form
- apply the same vertical layout for the unplanned expense form to keep the add control stationary

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e2b2ca1f64832cae8809fe05de8321