### PR TITLE
Allow add category pill to expand across chip rows

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -488,7 +488,7 @@ private extension CategoryChipsRow {
     }
 
     private var addCategoryButton: some View {
-        AddCategoryPill { isPresentingNewCategory = true }
+        AddCategoryPill(fillsWidth: true) { isPresentingNewCategory = true }
     }
 }
 
@@ -505,6 +505,7 @@ private struct PresentationDetentsCompat: ViewModifier {
 
 // MARK: - AddCategoryPill
 private struct AddCategoryPill: View {
+    var fillsWidth: Bool = false
     var onTap: () -> Void
     @EnvironmentObject private var themeManager: ThemeManager
 
@@ -515,11 +516,13 @@ private struct AddCategoryPill: View {
         }
         .buttonStyle(
             AddCategoryPillStyle(
-                tint: themeManager.selectedTheme.resolvedTint
+                tint: themeManager.selectedTheme.resolvedTint,
+                fillsWidth: fillsWidth
             )
         )
         .controlSize(.regular)
         .accessibilityLabel("Add Category")
+        .frame(maxWidth: fillsWidth ? .infinity : nil, alignment: .center)
     }
 }
 
@@ -567,6 +570,7 @@ private struct CategoryChip: View {
 // MARK: - Styles
 private struct AddCategoryPillStyle: ButtonStyle {
     let tint: Color
+    var fillsWidth: Bool = false
 
     func makeBody(configuration: Configuration) -> some View {
         let isActive = configuration.isPressed
@@ -583,7 +587,9 @@ private struct AddCategoryPillStyle: ButtonStyle {
         ) {
             configuration.label
                 .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: fillsWidth ? .infinity : nil, alignment: .center)
         }
+        .frame(maxWidth: fillsWidth ? .infinity : nil, alignment: .center)
         .overlay {
             if isActive {
                 capsule.strokeBorder(tint.opacity(0.35), lineWidth: 2)

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -349,7 +349,7 @@ private extension CategoryChipsRow {
     }
 
     private var addCategoryButton: some View {
-        AddCategoryPill {
+        AddCategoryPill(fillsWidth: true) {
             isPresentingNewCategory = true
         }
     }
@@ -358,6 +358,7 @@ private extension CategoryChipsRow {
 // MARK: - AddCategoryPill
 /// Compact, fixed “Add” control styled like a pill.
 private struct AddCategoryPill: View {
+    var fillsWidth: Bool = false
     var onTap: () -> Void
     @EnvironmentObject private var themeManager: ThemeManager
 
@@ -368,11 +369,13 @@ private struct AddCategoryPill: View {
         }
         .buttonStyle(
             AddCategoryPillStyle(
-                tint: themeManager.selectedTheme.resolvedTint
+                tint: themeManager.selectedTheme.resolvedTint,
+                fillsWidth: fillsWidth
             )
         )
         .controlSize(.regular)
         .accessibilityLabel("Add Category")
+        .frame(maxWidth: fillsWidth ? .infinity : nil, alignment: .center)
     }
 }
 
@@ -421,6 +424,7 @@ private struct CategoryChip: View {
 // MARK: - Styles
 private struct AddCategoryPillStyle: ButtonStyle {
     let tint: Color
+    var fillsWidth: Bool = false
 
     func makeBody(configuration: Configuration) -> some View {
         let isActive = configuration.isPressed
@@ -437,7 +441,9 @@ private struct AddCategoryPillStyle: ButtonStyle {
         ) {
             configuration.label
                 .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: fillsWidth ? .infinity : nil, alignment: .center)
         }
+        .frame(maxWidth: fillsWidth ? .infinity : nil, alignment: .center)
         .overlay {
             if isActive {
                 capsule.strokeBorder(tint.opacity(0.35), lineWidth: 2)


### PR DESCRIPTION
## Summary
- add an optional `fillsWidth` flag to `AddCategoryPill` and its style so the background can stretch across the cell while keeping the content centered
- render the add-category control as full-width in the planned and unplanned expense forms via the shared `CategoryChipsRow`

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e2b6357500832c9c7f89523b77e76e