### PR TITLE
fix: align expense chip glass clipping

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -389,7 +389,7 @@ private struct CategoryChipsRow: View {
     @State private var isPresentingNewCategory = false
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
-    private let chipRowClipShape = Capsule(style: .continuous)
+    private let chipRowClipShape = RoundedRectangle(cornerRadius: DS.Radius.l, style: .continuous)
 
     var body: some View {
         chipsScrollContainer()
@@ -462,7 +462,6 @@ private extension CategoryChipsRow {
         .ub_hideScrollIndicators()
         .ub_disableHorizontalBounce()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .clipped()
     }
 
     @ViewBuilder

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -238,7 +238,7 @@ private struct CategoryChipsRow: View {
     @Environment(\.platformCapabilities) private var capabilities
 
     private let verticalInset: CGFloat = DS.Spacing.s + DS.Spacing.xs
-    private let chipRowClipShape = Capsule(style: .continuous)
+    private let chipRowClipShape = RoundedRectangle(cornerRadius: DS.Radius.l, style: .continuous)
 
     var body: some View {
         chipsScrollContainer()
@@ -323,7 +323,6 @@ private extension CategoryChipsRow {
         .ub_hideScrollIndicators()
         .ub_disableHorizontalBounce()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .clipped()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- swap the capsule clip shape for a rounded rectangle in both expense chip rows to match the taller stack geometry
- keep the glass container clipped on OS 26+ while letting the horizontal chip scroll view render at full height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b75b6fe0832c994c01985ad73343