### PR TITLE
Enable interactive glass effect for add category pills

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -582,7 +582,8 @@ private struct AddCategoryPillStyle: ButtonStyle {
             fallbackTextColor: .primary,
             fallbackFill: DS.Colors.chipFill,
             fallbackStrokeColor: DS.Colors.chipFill,
-            fallbackStrokeLineWidth: 1
+            fallbackStrokeLineWidth: 1,
+            isInteractive: true
         ) {
             configuration.label
                 .font(.subheadline.weight(.semibold))

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -436,7 +436,8 @@ private struct AddCategoryPillStyle: ButtonStyle {
             fallbackTextColor: .primary,
             fallbackFill: DS.Colors.chipFill,
             fallbackStrokeColor: DS.Colors.chipFill,
-            fallbackStrokeLineWidth: 1
+            fallbackStrokeLineWidth: 1,
+            isInteractive: true
         ) {
             configuration.label
                 .font(.subheadline.weight(.semibold))

--- a/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
+++ b/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
@@ -12,6 +12,7 @@ struct CategoryChipPill<Label: View>: View {
     private var capsule: Capsule { Capsule(style: .continuous) }
 
     let isSelected: Bool
+    let isInteractive: Bool
     let glassTint: Color?
     let glassTextColor: Color
     let fallbackTextColor: Color
@@ -30,9 +31,11 @@ struct CategoryChipPill<Label: View>: View {
         fallbackFill: Color = DS.Colors.chipFill,
         fallbackStrokeColor: Color = DS.Colors.chipFill,
         fallbackStrokeLineWidth: CGFloat = 1,
+        isInteractive: Bool = false,
         @ViewBuilder label: @escaping () -> Label
     ) {
         self.isSelected = isSelected
+        self.isInteractive = isInteractive
         self.glassTint = glassTint
         self.glassTextColor = glassTextColor
         self.fallbackTextColor = fallbackTextColor
@@ -55,7 +58,7 @@ struct CategoryChipPill<Label: View>: View {
                 } else {
                     baseLabel
                         .foregroundStyle(glassTextColor)
-                        .glassEffect(.regular, in: capsule)
+                        .glassEffect(isInteractive ? .regular.interactive() : .regular, in: capsule)
                 }
             } else {
 #if DEBUG && LIQUID_GLASS_QA


### PR DESCRIPTION
## Summary
- add an interaction toggle to `CategoryChipPill` so non-selected controls can opt into the interactive glass effect on OS 26
- thread the new toggle through add-category button styles so the + Add pill animates when translucency is supported

## Testing
- not run (iOS simulator not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2cdefdf2c832cbb34158c5ca5b30f