### PR TITLE
Enable interactive glass highlight for add category pill

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -577,7 +577,8 @@ private struct AddCategoryPillStyle: ButtonStyle {
         let capsule = Capsule(style: .continuous)
 
         return CategoryChipPill(
-            isSelected: false,
+            isSelected: configuration.isPressed,
+            glassTint: tint,
             glassTextColor: .primary,
             fallbackTextColor: .primary,
             fallbackFill: DS.Colors.chipFill,

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -431,7 +431,8 @@ private struct AddCategoryPillStyle: ButtonStyle {
         let capsule = Capsule(style: .continuous)
 
         return CategoryChipPill(
-            isSelected: false,
+            isSelected: configuration.isPressed,
+            glassTint: tint,
             glassTextColor: .primary,
             fallbackTextColor: .primary,
             fallbackFill: DS.Colors.chipFill,


### PR DESCRIPTION
## Summary
- update the add-category pill style in the planned expense form to drive the interactive glass effect while pressed
- mirror the same behavior in the unplanned expense form to keep the styling consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2cef9d6a0832cbc5bf4a3be96b684