### PR TITLE
Adjust settings and presets scrolling

### DIFF
--- a/OffshoreBudgeting/Views/PresetsView.swift
+++ b/OffshoreBudgeting/Views/PresetsView.swift
@@ -34,7 +34,7 @@ struct PresetsView: View {
         RootTabPageScaffold(
             scrollBehavior: .always,
             spacing: DS.Spacing.s,
-            wrapsContentInScrollView: false
+            wrapsContentInScrollView: viewModel.items.isEmpty
         ) {
             EmptyView()
         } content: { proxy in

--- a/OffshoreBudgeting/Views/SettingsView.swift
+++ b/OffshoreBudgeting/Views/SettingsView.swift
@@ -376,18 +376,19 @@ struct SettingsView: View {
         tabBarGutter: RootTabPageProxy.TabBarGutter
     ) -> CGFloat {
         let base = horizontalSizeClass == .compact ? 0 : DS.Spacing.l
+        let scrollTailAllowance = DS.Spacing.m // Provide gentle overscroll consistency with other tabs.
         let tabChromeHeight: CGFloat = horizontalSizeClass == .compact ? 49 : 50
         let gutter = proxy.tabBarGutterSpacing(tabBarGutter)
 
         if capabilities.supportsOS26Translucency {
             // On OS26 we respect safe area; no extra is required beyond minor spacing.
-            return max(base - gutter, 0)
+            return max(base - gutter, 0) + scrollTailAllowance
         } else {
             // Legacy path: scaffold ignores the bottom safe area. Pad content by the
             // visible chrome (tab bar height) plus safe-area inset so the last card
             // remains fully visible above the opaque tab bar.
             let required = tabChromeHeight + proxy.safeAreaBottomInset
-            return max(required + base - gutter, 0)
+            return max(required + base - gutter, 0) + scrollTailAllowance
         }
     }
 


### PR DESCRIPTION
## Summary
- add extra bottom padding in Settings to provide consistent overscroll past the final card
- enable the Presets empty state to scroll by letting the scaffold wrap the content when no templates are loaded

## Testing
- not run (iOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2cfe25980832c8d84008a0d8c1f1f