### PR TITLE
Align edit sheet backgrounds with grouped canvas

### DIFF
--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -273,6 +273,24 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         }
     }
 
+    /// Neutral grouped container background that mirrors the system's form canvas.
+    var sheetBackground: Color {
+        switch self {
+        case .system:
+            return Color(UIColor { trait in
+                if trait.userInterfaceStyle == .dark {
+                    return UIColor.secondarySystemGroupedBackground
+                } else {
+                    return UIColor.systemGroupedBackground
+                }
+            })
+        case .classic, .ocean, .sunrise, .blossom, .lavender, .mint:
+            return Color(UIColor.systemGroupedBackground)
+        case .midnight, .forest, .sunset, .nebula:
+            return background
+        }
+    }
+
     /// Neutral foreground color suitable for primary labels within the theme.
     /// - Parameter colorScheme: The environment's resolved scheme. Used so that the
     ///   System theme can mirror the platform default of dark text in light mode and

--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -127,20 +127,14 @@ struct EditSheetScaffold<SheetContent: View>: View {
             Form { content }
                 .scrollContentBackground(.hidden)
                 .listRowBackground(rowBackground)
-                .ub_surfaceBackground(
-                    themeManager.selectedTheme,
-                    configuration: themeManager.glassConfiguration
-                )
+                .background(themeManager.selectedTheme.sheetBackground)
                 .ub_formStyleGrouped()
                 .ub_hideScrollIndicators()
                 .multilineTextAlignment(.leading)
         } else {
             Form { content }
                 .listRowBackground(rowBackground)
-                .ub_surfaceBackground(
-                    themeManager.selectedTheme,
-                    configuration: themeManager.glassConfiguration
-                )
+                .background(themeManager.selectedTheme.sheetBackground)
                 .ub_formStyleGrouped()
                 .ub_hideScrollIndicators()
                 .multilineTextAlignment(.leading)
@@ -150,7 +144,7 @@ struct EditSheetScaffold<SheetContent: View>: View {
     // MARK: Row Background
     private var rowBackground: some View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(themeManager.selectedTheme.secondaryBackground)
+            .fill(themeManager.selectedTheme.background)
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(separatorColor, lineWidth: 1)


### PR DESCRIPTION
## Summary
- add a grouped sheet background color to `AppTheme` that follows the system list canvas
- update `EditSheetScaffold` to render forms against the grouped sheet background while keeping row separators visible

## Testing
- not run (UI smoke tests require a simulator)


------
https://chatgpt.com/codex/tasks/task_e_68e2d531c1ec832cb829332b724e404c