### PR TITLE
Add reusable list row background helper for grouped styling

### DIFF
--- a/OffshoreBudgeting/Views/Components/UBFormListRowBackground.swift
+++ b/OffshoreBudgeting/Views/Components/UBFormListRowBackground.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Reusable list row background that cooperates with Liquid Glass on OS 26,
+/// and falls back to a rounded, grouped fill with a separator on legacy OSes.
+public struct UBFormListRowBackground: View {
+    public let theme: AppTheme
+    @Environment(\.platformCapabilities) private var capabilities
+
+    public init(theme: AppTheme) { self.theme = theme }
+
+    public var body: some View {
+        Group {
+            if capabilities.supportsOS26Translucency {
+                // Let system glass show through on modern OS
+                Color.clear
+            } else {
+                // Opaque grouped row for legacy OSes
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(.systemBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(Color.separator, lineWidth: 1)
+                    )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the reusable `UBFormListRowBackground` helper to support the new grouped row styling API

## Testing
- not run (Xcode tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e2dfb68298832c97eef6fd7560f974