### PR TITLE
Remove public access modifiers from UBFormListRowBackground

### DIFF
--- a/OffshoreBudgeting/Views/Components/UBFormListRowBackground.swift
+++ b/OffshoreBudgeting/Views/Components/UBFormListRowBackground.swift
@@ -2,13 +2,13 @@ import SwiftUI
 
 /// Reusable list row background that cooperates with Liquid Glass on OS 26,
 /// and falls back to a rounded, grouped fill with a separator on legacy OSes.
-public struct UBFormListRowBackground: View {
-    public let theme: AppTheme
+struct UBFormListRowBackground: View {
+    let theme: AppTheme
     @Environment(\.platformCapabilities) private var capabilities
 
-    public init(theme: AppTheme) { self.theme = theme }
+    init(theme: AppTheme) { self.theme = theme }
 
-    public var body: some View {
+    var body: some View {
         Group {
             if capabilities.supportsOS26Translucency {
                 // Let system glass show through on modern OS


### PR DESCRIPTION
## Summary
- remove the explicit `public` access modifier from `UBFormListRowBackground` so the struct and its members default to internal access

## Testing
- `xcodebuild -project OffshoreBudgeting.xcodeproj -scheme OffshoreBudgeting -destination 'platform=iOS Simulator,name=iPhone 15' build` *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e466db34832c9808438bd4ae40ae