### PR TITLE
Simplify UBFormListRowBackground conditional rendering

### DIFF
--- a/OffshoreBudgeting/Views/Components/UBFormListRowBackground.swift
+++ b/OffshoreBudgeting/Views/Components/UBFormListRowBackground.swift
@@ -9,19 +9,17 @@ struct UBFormListRowBackground: View {
     init(theme: AppTheme) { self.theme = theme }
 
     var body: some View {
-        Group {
-            if capabilities.supportsOS26Translucency {
-                // Let system glass show through on modern OS
-                Color.clear
-            } else {
-                // Opaque grouped row for legacy OSes
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color(.systemBackground))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .stroke(Color.separator, lineWidth: 1)
-                    )
-            }
+        if capabilities.supportsOS26Translucency {
+            // Let system glass show through on modern OS
+            Color.clear
+        } else {
+            // Opaque grouped row for legacy OSes
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.systemBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.separator, lineWidth: 1)
+                )
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove redundant Group wrapper from UBFormListRowBackground
- rely on direct conditional branches for modern and legacy row backgrounds

## Testing
- xcodebuild -project OffshoreBudgeting.xcodeproj -scheme OffshoreBudgeting -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e50b2df8832c8660aaad3968b15c