### PR TITLE
Align category chips rows into single form cell

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -393,10 +393,16 @@ private struct CategoryChipsRow: View {
     private let chipRowClipShape = Rectangle()
 
     var body: some View {
-        Group {
-            addCategoryButtonRow
-            categoryChipsListRow
+        UBFormRow {
+            HStack(spacing: DS.Spacing.s) {
+                addCategoryButton
+                chipsScrollContainer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .listRowBackground(UBFormListRowBackground(theme: themeManager.selectedTheme))
+        .listRowInsets(rowInsets)
+        .listRowSeparator(.hidden)
         .sheet(isPresented: $isPresentingNewCategory) {
             ExpenseCategoryEditorSheet(
                 initialName: "",
@@ -423,19 +429,6 @@ private struct CategoryChipsRow: View {
                 selectedCategoryID = first.objectID
             }
         }
-    }
-
-    private var addCategoryButtonRow: some View {
-        addCategoryButton
-            .padding(.horizontal, DS.Spacing.s)
-            .listRowBackground(UBFormListRowBackground(theme: themeManager.selectedTheme))
-            .listRowInsets(rowInsets)
-    }
-
-    private var categoryChipsListRow: some View {
-        chipsScrollContainer()
-            .listRowBackground(UBFormListRowBackground(theme: themeManager.selectedTheme))
-            .listRowInsets(rowInsets)
     }
 
     private var rowInsets: EdgeInsets {
@@ -500,7 +493,8 @@ private extension CategoryChipsRow {
     }
 
     private var addCategoryButton: some View {
-        AddCategoryPill(fillsWidth: true) { isPresentingNewCategory = true }
+        AddCategoryPill { isPresentingNewCategory = true }
+            .padding(.leading, DS.Spacing.s)
     }
 }
 

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -243,10 +243,16 @@ private struct CategoryChipsRow: View {
     private let chipRowClipShape = Rectangle()
 
     var body: some View {
-        Group {
-            addCategoryButtonRow
-            categoryChipsListRow
+        UBFormRow {
+            HStack(spacing: DS.Spacing.s) {
+                addCategoryButton
+                chipsScrollContainer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .listRowBackground(UBFormListRowBackground(theme: themeManager.selectedTheme))
+        .listRowInsets(rowInsets)
+        .listRowSeparator(.hidden)
         .sheet(isPresented: $isPresentingNewCategory) {
             // Build as a single expression to avoid opaque 'some View' type mismatches.
             let base = ExpenseCategoryEditorSheet(
@@ -285,19 +291,6 @@ private struct CategoryChipsRow: View {
                 selectedCategoryID = first.objectID
             }
         }
-    }
-
-    private var addCategoryButtonRow: some View {
-        addCategoryButton
-            .padding(.horizontal, DS.Spacing.s)
-            .listRowBackground(UBFormListRowBackground(theme: themeManager.selectedTheme))
-            .listRowInsets(rowInsets)
-    }
-
-    private var categoryChipsListRow: some View {
-        chipsScrollContainer()
-            .listRowBackground(UBFormListRowBackground(theme: themeManager.selectedTheme))
-            .listRowInsets(rowInsets)
     }
 
     private var rowInsets: EdgeInsets {
@@ -362,9 +355,10 @@ private extension CategoryChipsRow {
     }
 
     private var addCategoryButton: some View {
-        AddCategoryPill(fillsWidth: true) {
+        AddCategoryPill {
             isPresentingNewCategory = true
         }
+        .padding(.leading, DS.Spacing.s)
     }
 }
 


### PR DESCRIPTION
## Summary
- refactor the category chips rows in the add planned and unplanned expense forms into a single UBFormRow
- embed the add-category pill alongside the chips while preserving chip sizing
- apply the shared row background, insets, and hidden separator to the unified row

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2e88d3a84832ca134ca3fad581f48