### PR TITLE
Allow category chip rows to use default list background

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -30,7 +30,6 @@ struct AddPlannedExpenseView: View {
     /// We don't call `dismiss()` directly anymore (the scaffold handles it),
     /// but we keep this in case future platform-specific work needs it.
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var themeManager: ThemeManager
     @EnvironmentObject private var cardPickerStore: CardPickerStore
     @StateObject private var vm: AddPlannedExpenseViewModel
     @State private var isAssigningToBudget: Bool
@@ -379,7 +378,6 @@ private struct CategoryChipsRow: View {
     @Binding var selectedCategoryID: NSManagedObjectID?
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.platformCapabilities) private var capabilities
-    @EnvironmentObject private var themeManager: ThemeManager
 
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(key: "name", ascending: true,
@@ -400,7 +398,6 @@ private struct CategoryChipsRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .listRowBackground(UBFormListRowBackground(theme: themeManager.selectedTheme))
         .listRowInsets(rowInsets)
         .listRowSeparator(.hidden)
         .sheet(isPresented: $isPresentingNewCategory) {

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -26,7 +26,6 @@ struct AddUnplannedExpenseView: View {
 
     // MARK: State
     @StateObject private var vm: AddUnplannedExpenseViewModel
-    @EnvironmentObject private var themeManager: ThemeManager
     @EnvironmentObject private var cardPickerStore: CardPickerStore
     @State private var isPresentingAddCard = false
     
@@ -225,7 +224,6 @@ private struct CategoryChipsRow: View {
 
     // MARK: Environment
     @Environment(\.managedObjectContext) private var viewContext
-    @EnvironmentObject private var themeManager: ThemeManager
 
 
     // MARK: Live Fetch
@@ -250,7 +248,6 @@ private struct CategoryChipsRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .listRowBackground(UBFormListRowBackground(theme: themeManager.selectedTheme))
         .listRowInsets(rowInsets)
         .listRowSeparator(.hidden)
         .sheet(isPresented: $isPresentingNewCategory) {


### PR DESCRIPTION
## Summary
- remove the custom UBFormListRowBackground override from the planned and unplanned expense category chip rows so EditSheetScaffold styling applies
- retain the existing insets, separators, and layout around the chips and add button

## Testing
- not run (UI verification requires iOS 17 / OS 26 simulators not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2eb63eda8832c8da757f6d9cc3c8f