### PR TITLE
Add grouped row background to edit sheets

### DIFF
--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -291,6 +291,20 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         }
     }
 
+    /// Row background used within grouped forms and lists.
+    /// Mirrors the native grouped appearance by matching the system's
+    /// secondary grouped surface when following the platform theme and
+    /// reusing each custom palette's secondary background so their
+    /// tailored grouped shades remain consistent in light and dark modes.
+    var groupedRowBackground: Color {
+        switch self {
+        case .system:
+            return Color(UIColor.secondarySystemGroupedBackground)
+        default:
+            return secondaryBackground
+        }
+    }
+
     /// Neutral foreground color suitable for primary labels within the theme.
     /// - Parameter colorScheme: The environment's resolved scheme. Used so that the
     ///   System theme can mirror the platform default of dark text in light mode and

--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -144,7 +144,7 @@ struct EditSheetScaffold<SheetContent: View>: View {
     // MARK: Row Background
     private var rowBackground: some View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(themeManager.selectedTheme.background)
+            .fill(themeManager.selectedTheme.groupedRowBackground)
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(separatorColor, lineWidth: 1)


### PR DESCRIPTION
## Summary
- add a reusable grouped row background accessor to `AppTheme`
- apply the grouped row styling to edit sheet rows for consistent contrast

## Testing
- not run (simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2ef4d9e34832c98711ef7baa9fcac