### PR TITLE
Adapt edit sheet row backgrounds to color scheme

### DIFF
--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -291,6 +291,19 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         }
     }
 
+    /// Theme-aware background for grouped form rows to match system styling.
+    /// - Parameter colorScheme: The resolved environment scheme for the view.
+    func formRowBackground(for colorScheme: ColorScheme) -> Color {
+        switch self {
+        case .system:
+            return colorScheme == .dark
+                ? Color(UIColor.secondarySystemGroupedBackground)
+                : Color(UIColor.systemBackground)
+        default:
+            return background
+        }
+    }
+
     /// Neutral foreground color suitable for primary labels within the theme.
     /// - Parameter colorScheme: The environment's resolved scheme. Used so that the
     ///   System theme can mirror the platform default of dark text in light mode and

--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -49,6 +49,7 @@ struct EditSheetScaffold<SheetContent: View>: View {
     // MARK: Environment
     @Environment(\.dismiss) private var dismiss
     @Environment(\.platformCapabilities) private var platformCapabilities
+    @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var themeManager: ThemeManager
 
     // Selection state for detents (compat type)
@@ -144,7 +145,7 @@ struct EditSheetScaffold<SheetContent: View>: View {
     // MARK: Row Background
     private var rowBackground: some View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(themeManager.selectedTheme.background)
+            .fill(themeManager.selectedTheme.formRowBackground(for: colorScheme))
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(separatorColor, lineWidth: 1)


### PR DESCRIPTION
## Summary
- add a form row background helper to AppTheme that adapts the system theme to light and dark modes
- update EditSheetScaffold to use the adaptive row background while respecting the selected theme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2f08ed794832c805fca260f28ca16