### PR TITLE
Update budget detail empty states for inactive periods

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -513,6 +513,7 @@ struct HomeView: View {
                 onSegmentChange: { newSegment in
                     self.selectedSegment = newSegment
                 },
+                onRequestCreateBudget: { isPresentingAddBudget = true },
                 headerManagesPadding: true,
                 header: header,
                 listHeaderBehavior: .omitsHeader,


### PR DESCRIPTION
## Summary
- detect when the displayed budget period is inactive and surface a create-budget callback from `BudgetDetailsView`
- update the planned and variable expense empty states to show "+ Create Budget" for inactive periods while preserving the add-expense CTA when active
- hook the home view into the callback so the Create Budget button opens the existing budget-creation flow

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2f4ae72d4832c8a4093682aa00b3f