### PR TITLE
Ensure card detail list has trailing spacer

### DIFF
--- a/OffshoreBudgeting/Views/CardDetailView.swift
+++ b/OffshoreBudgeting/Views/CardDetailView.swift
@@ -177,6 +177,15 @@ struct CardDetailView: View {
 
             // Expenses list (already returns a Section)
             expensesSection
+
+            Section {
+                cardDetailBottomSpacer()
+            }
+            .listRowInsets(.init())
+            .listRowSeparator(.hidden)
+            .listRowBackground(Color.clear)
+            .accessibilityHidden(true)
+            .allowsHitTesting(false)
         }
         .ub_listStyleLiquidAware()
         .ub_hideScrollIndicators()
@@ -194,7 +203,9 @@ struct CardDetailView: View {
     // even when content is short, and to keep spacing consistent above the tab bar.
     @ViewBuilder
     private func cardDetailBottomSpacer() -> some View {
-        Color.clear.frame(height: CardDetailListBottomInsetMetrics.bottomInset(for: layoutContext))
+        Color.clear
+            .frame(height: CardDetailListBottomInsetMetrics.bottomInset(for: layoutContext))
+            .listRowBackground(Color.clear)
             .allowsHitTesting(false)
             .accessibilityHidden(true)
     }
@@ -536,16 +547,18 @@ private extension View {
 }
 
 private enum CardDetailListBottomInsetMetrics {
-    #if os(iOS)
-    #if targetEnvironment(macCatalyst)
-    static func bottomInset(for layoutContext: ResponsiveLayoutContext) -> CGFloat { 0 }
-    #else
+    #if os(iOS) && !targetEnvironment(macCatalyst)
     // Match BudgetDetailsView behavior: ensure at least the tab bar height is
     // represented so the list always scrolls comfortably.
     private static let compactTabBarHeight: CGFloat = 49
     private static let regularTabBarHeight: CGFloat = 49
+    #endif
 
     static func bottomInset(for layoutContext: ResponsiveLayoutContext) -> CGFloat {
+        #if os(iOS)
+        #if targetEnvironment(macCatalyst)
+        return max(layoutContext.safeArea.bottom, DS.Spacing.xxl)
+        #else
         let safeAreaBottom = layoutContext.safeArea.bottom
         let sizeClass = layoutContext.horizontalSizeClass ?? .compact
         let tabBarHeight = sizeClass == .regular ? regularTabBarHeight : compactTabBarHeight
@@ -554,9 +567,9 @@ private enum CardDetailListBottomInsetMetrics {
         } else {
             return safeAreaBottom + tabBarHeight
         }
+        #endif
+        #else
+        return max(layoutContext.safeArea.bottom, DS.Spacing.xxl)
+        #endif
     }
-    #endif
-    #else
-    static func bottomInset(for layoutContext: ResponsiveLayoutContext) -> CGFloat { 0 }
-    #endif
 }


### PR DESCRIPTION
## Summary
- append an invisible trailing section so CardDetailView lists always have scrollable gutter
- reuse CardDetailListBottomInsetMetrics for the spacer and add a desktop-friendly default inset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e306fd9108832cba5a16d1ab66994d