### PR TITLE
Ensure card detail navigation fills overlay

### DIFF
--- a/OffshoreBudgeting/Views/CardDetailView.swift
+++ b/OffshoreBudgeting/Views/CardDetailView.swift
@@ -54,6 +54,7 @@ struct CardDetailView: View {
     // MARK: Body
     var body: some View {
         navigationContainer
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .ub_navigationBackground(
             theme: themeManager.selectedTheme,
             configuration: themeManager.glassConfiguration


### PR DESCRIPTION
## Summary
- ensure `CardDetailView`'s navigation container expands to fill its overlay presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c6eaeec8832cb15e68fc0a40e5e5