### PR TITLE
Enable editing swipe action on card expenses

### DIFF
--- a/OffshoreBudgeting/Views/CardDetailView.swift
+++ b/OffshoreBudgeting/Views/CardDetailView.swift
@@ -28,6 +28,7 @@ struct CardDetailView: View {
     @FocusState private var isSearchFieldFocused: Bool
     // Add flows
     @State private var isPresentingAddPlanned: Bool = false
+    @State private var expensePendingEdit: CardExpense?
     @State private var expensePendingDeletion: CardExpense?
     @State private var isConfirmingDelete: Bool = false
     @State private var deletionError: DeletionError?
@@ -86,6 +87,9 @@ struct CardDetailView: View {
                 initialCardID: card.objectID
             )
             .environment(\.managedObjectContext, CoreDataService.shared.viewContext)
+        }
+        .sheet(item: $expensePendingEdit) { expense in
+            editingSheet(for: expense)
         }
         .alert("Delete Expense?", isPresented: $isConfirmingDelete) {
             Button("Delete", role: .destructive) {
@@ -262,7 +266,7 @@ struct CardDetailView: View {
                     }
                         .unifiedSwipeActions(
                             UnifiedSwipeConfig(allowsFullSwipeToDelete: false),
-                            onEdit: nil,
+                            onEdit: { presentEdit(for: pair.element) },
                             onDelete: { requestDelete(pair.element) }
                         )
                 }
@@ -305,6 +309,29 @@ struct CardDetailView: View {
             .ub_preOS26ListRowBackground(themeManager.selectedTheme.secondaryBackground)
     }
 
+    @ViewBuilder
+    private func editingSheet(for expense: CardExpense) -> some View {
+        if expense.isPlanned {
+            AddPlannedExpenseView(
+                plannedExpenseID: expense.objectID,
+                preselectedBudgetID: nil,
+                defaultSaveAsGlobalPreset: false,
+                showAssignBudgetToggle: true,
+                onSaved: { handleExpenseEdited() },
+                initialCardID: card.objectID
+            )
+            .environment(\.managedObjectContext, CoreDataService.shared.viewContext)
+        } else {
+            AddUnplannedExpenseView(
+                unplannedExpenseID: expense.objectID,
+                initialCardID: card.objectID,
+                initialDate: expense.date,
+                onSaved: { handleExpenseEdited() }
+            )
+            .environment(\.managedObjectContext, CoreDataService.shared.viewContext)
+        }
+    }
+
     private func requestDelete(_ expense: CardExpense) {
         if confirmBeforeDelete {
             expensePendingDeletion = expense
@@ -312,6 +339,16 @@ struct CardDetailView: View {
         } else {
             performDelete(expense)
         }
+    }
+
+    private func presentEdit(for expense: CardExpense) {
+        guard expense.objectID != nil else { return }
+        expensePendingEdit = expense
+    }
+
+    private func handleExpenseEdited() {
+        expensePendingEdit = nil
+        Task { await viewModel.load() }
     }
 
     private func handleDelete(_ offsets: IndexSet) {


### PR DESCRIPTION
## Summary
- add edit support to the card detail expense list using the shared swipe action configuration
- present the appropriate planned or variable expense editing sheet and refresh the view after saving

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3e9ad6ca4832ca319b2c63c66594f