### PR TITLE
Add planned expense propagation scopes and confirmation flow

### DIFF
--- a/OffshoreBudgeting/Resources/PlannedExpenseService+Templates.swift
+++ b/OffshoreBudgeting/Resources/PlannedExpenseService+Templates.swift
@@ -141,93 +141,64 @@ extension PlannedExpenseService {
         }
     }
 
-    // MARK: Update Template + Propagate
-    /// Updates a global template and optionally propagates the same changes to
-    /// all existing children starting from a specific date.
+    // MARK: Update Template Hierarchy
+    /// Applies updates to a template hierarchy using the provided propagation scope.
     /// - Parameters:
-    ///   - template: The global template to update.
-    ///   - title: Optional new description/title.
-    ///   - plannedAmount: Optional new planned amount.
-    ///   - actualAmount: Optional new actual amount.
-    ///   - transactionDate: Optional new transaction date.
-    ///   - startDate: If provided, child instances with a `transactionDate`
-    ///                on/after this date will receive the same updates. Pass
-    ///                `nil` to leave existing children untouched.
-    ///   - context: NSManagedObjectContext used for fetches.
-    func updateTemplate(_ template: PlannedExpense,
-                        title: String? = nil,
-                        plannedAmount: Double? = nil,
-                        actualAmount: Double? = nil,
-                        transactionDate: Date? = nil,
-                        propagateToChildrenFrom startDate: Date? = nil,
-                        in context: NSManagedObjectContext) {
-        // Update the template itself
-        if let title { template.descriptionText = title }
-        if let plannedAmount { template.plannedAmount = plannedAmount }
-        if let actualAmount { template.actualAmount = actualAmount }
-        if let transactionDate { template.transactionDate = transactionDate }
+    ///   - expense: The expense that was directly edited (template or child).
+    ///   - scope: Determines which related records should also be updated.
+    ///   - title: Optional replacement description/title.
+    ///   - plannedAmount: Optional planned amount to apply.
+    ///   - actualAmount: Optional actual amount to apply.
+    ///   - transactionDate: Optional transaction date to apply.
+    ///   - context: Managed object context for fetches.
+    func updateTemplateHierarchy(for expense: PlannedExpense,
+                                scope: PlannedExpenseUpdateScope,
+                                title: String? = nil,
+                                plannedAmount: Double? = nil,
+                                actualAmount: Double? = nil,
+                                transactionDate: Date? = nil,
+                                in context: NSManagedObjectContext) {
+        let template: PlannedExpense?
+        if expense.isGlobal {
+            template = expense
+        } else if let templateID = expense.globalTemplateID {
+            template = fetchTemplate(withID: templateID, in: context)
+        } else {
+            template = nil
+        }
 
-        // Optionally propagate to children
-        guard let startDate else { return }
+        let fallbackReferenceDate = scope.referenceDate ?? expense.transactionDate
+
+        func applyUpdates(to target: PlannedExpense) {
+            if let title { target.descriptionText = title }
+            if let plannedAmount { target.plannedAmount = plannedAmount }
+            if let actualAmount { target.actualAmount = actualAmount }
+            if let transactionDate { target.transactionDate = transactionDate }
+        }
+
+        applyUpdates(to: expense)
+
+        if let template, template != expense, scope.includesTemplate {
+            applyUpdates(to: template)
+        }
+
+        guard let template else { return }
         let children = fetchChildren(of: template, in: context)
         for child in children {
-            if let childDate = child.transactionDate, childDate < startDate { continue }
-            if let title { child.descriptionText = title }
-            if let plannedAmount { child.plannedAmount = plannedAmount }
-            if let actualAmount { child.actualAmount = actualAmount }
-            if let transactionDate { child.transactionDate = transactionDate }
+            if child == expense { continue }
+            if scope.shouldIncludeChild(with: child.transactionDate, fallbackReferenceDate: fallbackReferenceDate) {
+                applyUpdates(to: child)
+            }
         }
     }
 
-    // MARK: Update Child + Optionally Parent/Future Siblings
-    /// Updates a child PlannedExpense. When `applyToFutureInstances` is true
-    /// the parent template (if any) is updated and the same changes are applied
-    /// to all sibling instances with a `transactionDate` on/after the current
-    /// child's date.
-    func updateChild(_ child: PlannedExpense,
-                     title: String? = nil,
-                     plannedAmount: Double? = nil,
-                     actualAmount: Double? = nil,
-                     transactionDate: Date? = nil,
-                     applyToFutureInstances: Bool = false,
-                     in context: NSManagedObjectContext) {
-        // Update the child itself
-        if let title { child.descriptionText = title }
-        if let plannedAmount { child.plannedAmount = plannedAmount }
-        if let actualAmount { child.actualAmount = actualAmount }
-        if let transactionDate { child.transactionDate = transactionDate }
-
-        guard applyToFutureInstances, let templateID = child.globalTemplateID else { return }
-
-        // Fetch the parent template
-        let req: NSFetchRequest<PlannedExpense> = PlannedExpense.fetchRequest()
-        req.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "id == %@", templateID as CVarArg),
+    private func fetchTemplate(withID id: UUID, in context: NSManagedObjectContext) -> PlannedExpense? {
+        let request: NSFetchRequest<PlannedExpense> = PlannedExpense.fetchRequest()
+        request.fetchLimit = 1
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "id == %@", id as CVarArg),
             NSPredicate(format: "isGlobal == YES")
         ])
-        req.fetchLimit = 1
-        guard let parent = try? context.fetch(req).first else { return }
-
-        // Update parent with the same fields
-        if let title { parent.descriptionText = title }
-        if let plannedAmount { parent.plannedAmount = plannedAmount }
-        if let actualAmount { parent.actualAmount = actualAmount }
-        if let transactionDate { parent.transactionDate = transactionDate }
-
-        // Propagate to other future siblings
-        let siblings = fetchChildren(of: parent, in: context)
-        for sib in siblings {
-            // Skip the child we already updated
-            if sib == child { continue }
-            if let childDate = child.transactionDate,
-               let sibDate = sib.transactionDate,
-               sibDate < childDate {
-                continue
-            }
-            if let title { sib.descriptionText = title }
-            if let plannedAmount { sib.plannedAmount = plannedAmount }
-            if let actualAmount { sib.actualAmount = actualAmount }
-            if let transactionDate { sib.transactionDate = transactionDate }
-        }
+        return try? context.fetch(request).first
     }
 }

--- a/OffshoreBudgeting/Services/PlannedExpenseUpdateScope.swift
+++ b/OffshoreBudgeting/Services/PlannedExpenseUpdateScope.swift
@@ -1,0 +1,68 @@
+//
+//  PlannedExpenseUpdateScope.swift
+//  SoFar
+//
+//  Defines propagation scopes for planned expense updates so that templates
+//  and their instantiated children can stay in sync consistently across the app.
+//
+
+import Foundation
+
+/// Describes how edits to a planned expense should propagate through a template
+/// hierarchy.
+enum PlannedExpenseUpdateScope {
+    /// Update only the targeted expense.
+    case onlyThis
+    /// Update the targeted expense plus instances with a transaction date on or before the reference date.
+    case past(referenceDate: Date)
+    /// Update the targeted expense plus instances with a transaction date on or after the reference date.
+    case future(referenceDate: Date)
+    /// Update the targeted expense plus all instances regardless of date.
+    case all(referenceDate: Date)
+
+    /// Returns the reference date associated with the scope, if any.
+    var referenceDate: Date? {
+        switch self {
+        case .onlyThis:
+            return nil
+        case let .past(referenceDate),
+             let .future(referenceDate),
+             let .all(referenceDate):
+            return referenceDate
+        }
+    }
+
+    /// Indicates whether this scope should also update the template when the edit originates from a child.
+    var includesTemplate: Bool {
+        switch self {
+        case .onlyThis:
+            return false
+        case .past, .future, .all:
+            return true
+        }
+    }
+
+    /// Determines whether a child with the given date should be updated for the scope.
+    /// - Parameters:
+    ///   - date: The child's transaction date.
+    ///   - fallbackReferenceDate: A fallback reference date to use when the scope lacks one.
+    /// - Returns: `true` if the child should be updated under this scope.
+    func shouldIncludeChild(with date: Date?, fallbackReferenceDate: Date?) -> Bool {
+        switch self {
+        case .onlyThis:
+            return false
+        case .all:
+            return true
+        case let .future(referenceDate):
+            let pivot = referenceDate ?? fallbackReferenceDate
+            guard let pivot else { return true }
+            guard let date else { return true }
+            return date >= pivot
+        case let .past(referenceDate):
+            let pivot = referenceDate ?? fallbackReferenceDate
+            guard let pivot else { return true }
+            guard let date else { return true }
+            return date <= pivot
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable PlannedExpenseUpdateScope to describe how template updates propagate
- refactor PlannedExpenseService template helpers to apply updates using the new scope
- update the add planned expense view model and view to prompt for a propagation scope before saving linked expenses

## Testing
- Not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e408638f5c832ca90c7be5ee672856