### PR TITLE
Dismiss Add Planned Expense sheet when scoped save succeeds

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -271,16 +271,24 @@ struct AddPlannedExpenseView: View {
             isPresented: $isShowingScopeDialog
         ) {
             Button("Only this expense") {
-                _ = performSave(scope: .onlyThis)
+                if performSave(scope: .onlyThis) {
+                    dismiss()
+                }
             }
             Button("Past instances") {
-                _ = performSave(scope: .past(referenceDate: vm.transactionDate))
+                if performSave(scope: .past(referenceDate: vm.transactionDate)) {
+                    dismiss()
+                }
             }
             Button("Future instances") {
-                _ = performSave(scope: .future(referenceDate: vm.transactionDate))
+                if performSave(scope: .future(referenceDate: vm.transactionDate)) {
+                    dismiss()
+                }
             }
             Button("All instances") {
-                _ = performSave(scope: .all(referenceDate: vm.transactionDate))
+                if performSave(scope: .all(referenceDate: vm.transactionDate)) {
+                    dismiss()
+                }
             }
             Button("Cancel", role: .cancel) { }
         }


### PR DESCRIPTION
## Summary
- trigger dismiss() after each confirmation dialog scoped save to close the sheet when the save succeeds

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e41394bf9c832c8934c85be767e65a