### PR TITLE
Fix CategoryRowView label parameter usage

### DIFF
--- a/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
+++ b/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
@@ -138,6 +138,7 @@ struct ExpenseCategoryManagerView: View {
     private func categoryRow(for category: ExpenseCategory) -> some View {
         CategoryRowView(
             config: UnifiedSwipeConfig(allowsFullSwipeToDelete: false),
+            label: { rowLabel(for: category) },
             onTap: { categoryToEdit = category },
             onEdit: { categoryToEdit = category },
             onDelete: {
@@ -150,9 +151,7 @@ struct ExpenseCategoryManagerView: View {
                     deleteCategory(category)
                 }
             }
-        ) {
-            rowLabel(for: category)
-        }
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- update the ExpenseCategoryManagerView row builder to use the explicit label parameter when constructing CategoryRowView

## Testing
- ❌ `xcodebuild -project OffshoreBudgeting.xcodeproj -scheme OffshoreBudgeting -sdk iphonesimulator -destination 'generic/platform=iOS' build` *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e42f0a8e64832cbcfdbf4b4fb1051c