### PR TITLE
Ensure root tabs add legacy chrome padding on older OS versions

### DIFF
--- a/OffshoreBudgeting/Views/CardsView.swift
+++ b/OffshoreBudgeting/Views/CardsView.swift
@@ -28,6 +28,7 @@ struct CardsView: View {
     @StateObject private var viewModel = CardsViewModel()
     @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.platformCapabilities) private var capabilities
+    @Environment(\.rootTabLegacyChromeInset) private var rootTabLegacyChromeInset
     @State private var isPresentingAddCard = false
     @State private var editingCard: CardItem? = nil // NEW: for edit sheet
     @State private var isPresentingAddExpense = false
@@ -280,6 +281,7 @@ struct CardsView: View {
                 onEdit: { editingCard = selected }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.bottom, rootTabLegacyChromeInset)
             .ignoresSafeArea(edges: [.horizontal, .bottom])
             .transition(
                 .asymmetric(

--- a/OffshoreBudgeting/Views/Components/RootTabPageScaffold.swift
+++ b/OffshoreBudgeting/Views/Components/RootTabPageScaffold.swift
@@ -147,7 +147,8 @@ struct RootTabPageScaffold<Header: View, Content: View>: View {
             spacing: spacing,
             combinedHeight: combinedHeight,
             availableHeight: availableHeight,
-            isScrollEnabled: isScrollEnabled
+            isScrollEnabled: isScrollEnabled,
+            platformCapabilities: platformCapabilities
         )
 
         Group {
@@ -198,6 +199,7 @@ struct RootTabPageScaffold<Header: View, Content: View>: View {
                     .modifier(IgnoreBottomSafeAreaIfClassic(capabilities: platformCapabilities))
             }
         }
+        .environment(\.rootTabLegacyChromeInset, proxy.legacyTabBarOverlayInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: stackAlignment)
         .onPreferenceChange(RootTabSectionHeightPreferenceKey.self, perform: updateHeights)
         .ub_captureSafeAreaInsets()
@@ -310,6 +312,9 @@ struct RootTabPageProxy {
     let combinedHeight: CGFloat
     let availableHeight: CGFloat
     let isScrollEnabled: Bool
+    let platformCapabilities: PlatformCapabilities
+
+    private static let legacyTabBarChromeHeight: CGFloat = 49
 
     /// Controls the amount of vertical spacing inserted between tab content and the tab bar.
     enum TabBarGutter {
@@ -377,7 +382,7 @@ struct RootTabPageProxy {
     }
 
     var standardTabContentBottomPadding: CGFloat {
-        safeAreaBottomInset + tabBarGutterSpacing
+        tabContentBottomPadding()
     }
 
     func tabContentBottomPadding(
@@ -387,7 +392,31 @@ struct RootTabPageProxy {
     ) -> CGFloat {
         let safeAreaContribution = includeSafeArea ? safeAreaBottomInset : 0
         let gutterSpacing = tabBarGutterSpacing(tabBarGutter)
-        return gutterSpacing + safeAreaContribution + extraBottom
+        let legacyChromeContribution = legacyTabBarChromePadding(includeSafeArea: includeSafeArea)
+        return gutterSpacing + safeAreaContribution + legacyChromeContribution + extraBottom
+    }
+
+    var legacyTabBarOverlayInset: CGFloat {
+        #if os(iOS)
+        guard !platformCapabilities.supportsOS26Translucency else { return 0 }
+        return safeAreaBottomInset + Self.legacyTabBarChromeHeight
+        #else
+        return 0
+        #endif
+    }
+
+    private func legacyTabBarChromePadding(includeSafeArea: Bool) -> CGFloat {
+        #if os(iOS)
+        guard !platformCapabilities.supportsOS26Translucency else { return 0 }
+        let chromeHeight = Self.legacyTabBarChromeHeight
+        if includeSafeArea {
+            return chromeHeight
+        } else {
+            return chromeHeight + safeAreaBottomInset
+        }
+        #else
+        return 0
+        #endif
     }
 
     func standardContentInsets(
@@ -480,5 +509,16 @@ extension View {
                     tabBarGutter: tabBarGutter
                 )
             )
+    }
+}
+
+private struct RootTabLegacyChromeInsetKey: EnvironmentKey {
+    static var defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    var rootTabLegacyChromeInset: CGFloat {
+        get { self[RootTabLegacyChromeInsetKey.self] }
+        set { self[RootTabLegacyChromeInsetKey.self] = newValue }
     }
 }

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -65,7 +65,6 @@ struct HomeView: View {
                 .rootTabContentPadding(
                     proxy,
                     horizontal: 0,
-                    includeSafeArea: false,
                     tabBarGutter: proxy.compactAwareTabBarGutter
                 )
         }

--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -160,7 +160,7 @@ struct IncomeView: View {
     }
 
     private func contentBottomInset(using proxy: RootTabPageProxy) -> CGFloat {
-        proxy.safeAreaBottomInset + DS.Spacing.s
+        DS.Spacing.s
     }
 
     private let landscapeLayoutMinimumWidth: CGFloat = 780
@@ -328,7 +328,6 @@ struct IncomeView: View {
             horizontal: horizontalInset,
             extraTop: DS.Spacing.s,
             extraBottom: contentBottomInset(using: proxy),
-            includeSafeArea: false,
             tabBarGutter: gutter
         )
         .frame(
@@ -364,7 +363,6 @@ struct IncomeView: View {
             horizontal: horizontalInset,
             extraTop: DS.Spacing.s,
             extraBottom: contentBottomInset(using: proxy),
-            includeSafeArea: false,
             tabBarGutter: gutter
         )
         .frame(
@@ -392,7 +390,6 @@ struct IncomeView: View {
                 horizontal: horizontalInset,
                 extraTop: DS.Spacing.s,
                 extraBottom: contentBottomInset(using: proxy),
-                includeSafeArea: false,
                 tabBarGutter: gutter
             )
         }

--- a/OffshoreBudgeting/Views/PresetsView.swift
+++ b/OffshoreBudgeting/Views/PresetsView.swift
@@ -121,7 +121,6 @@ struct PresetsView: View {
             proxy,
             horizontal: 0,
             extraTop: DS.Spacing.s,
-            includeSafeArea: false,
             tabBarGutter: proxy.compactAwareTabBarGutter
         )
         // MARK: Data lifecycle

--- a/OffshoreBudgeting/Views/SettingsView.swift
+++ b/OffshoreBudgeting/Views/SettingsView.swift
@@ -276,7 +276,6 @@ struct SettingsView: View {
                 using: proxy,
                 tabBarGutter: tabBarGutter
             ),
-            includeSafeArea: false,
             tabBarGutter: tabBarGutter
         )
     }
@@ -376,20 +375,9 @@ struct SettingsView: View {
         tabBarGutter: RootTabPageProxy.TabBarGutter
     ) -> CGFloat {
         let base = horizontalSizeClass == .compact ? 0 : DS.Spacing.l
-        let scrollTailAllowance = DS.Spacing.l 
-        let tabChromeHeight: CGFloat = horizontalSizeClass == .compact ? 49 : 50
+        let scrollTailAllowance = DS.Spacing.l
         let gutter = proxy.tabBarGutterSpacing(tabBarGutter)
-
-        if capabilities.supportsOS26Translucency {
-            // On OS26 we respect safe area; no extra is required beyond minor spacing.
-            return max(base - gutter, 0) + scrollTailAllowance
-        } else {
-            // Legacy path: scaffold ignores the bottom safe area. Pad content by the
-            // visible chrome (tab bar height) plus safe-area inset so the last card
-            // remains fully visible above the opaque tab bar.
-            let required = tabChromeHeight + proxy.safeAreaBottomInset
-            return max(required + base - gutter, 0) + scrollTailAllowance
-        }
+        return max(base - gutter, 0) + scrollTailAllowance
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- update RootTabPageProxy to include legacy tab bar chrome padding when OS 26 translucency is unavailable and surface the inset via environment
- drop ad-hoc safe-area overrides in Home, Income, Presets, and Settings now that the scaffold handles legacy chrome spacing
- pad Cards overlays with the shared inset so detail sheets sit above the opaque tab bar

## Testing
- not run (iOS simulators are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4393d6454832c80a70024ff05508c