### PR TITLE
Respect legacy safe areas in root tab scaffolds

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootTabPageScaffold.swift
+++ b/OffshoreBudgeting/Views/Components/RootTabPageScaffold.swift
@@ -184,17 +184,18 @@ struct RootTabPageScaffold<Header: View, Content: View>: View {
                         .frame(maxWidth: .infinity, alignment: stackAlignment)
                     }
                     .ub_hideScrollIndicators()
-                    // On classic OS, allow content under the tab bar and control
-                    // spacing via `rootTabContentPadding`. On OS 26, respect the
-                    // safe area to avoid intercepting tab bar gestures.
+                    // Respect the bottom safe area so the scroll tail remains
+                    // reachable. Legacy platforms continue to rely on
+                    // `rootTabContentPadding` for any additional spacing above
+                    // the tab bar, while OS 26 preserves the existing Liquid
+                    // Glass treatment.
                     .modifier(IgnoreBottomSafeAreaIfClassic(capabilities: platformCapabilities))
                 }
                 .frame(maxWidth: .infinity, alignment: stackAlignment)
             } else {
                 stackContent(using: proxy)
-                    // Allow content to extend under the tab bar in non-scrolling
-                    // layouts as well. Individual screens add any desired
-                    // bottom spacing via `rootTabContentPadding`.
+                    // Respect the bottom safe area in non-scrolling layouts as
+                    // well so controls remain accessible above the tab bar.
                     .modifier(IgnoreBottomSafeAreaIfClassic(capabilities: platformCapabilities))
             }
         }
@@ -450,10 +451,18 @@ private struct IgnoreBottomSafeAreaIfClassic: ViewModifier {
 
     func body(content: Content) -> some View {
         if capabilities.supportsOS26Translucency {
-            content // respect safe area on OS 26
-        } else {
-            content.ub_ignoreSafeArea(edges: .bottom)
+            return content // OS 26 already applies the Liquid Glass safe-area rules.
         }
+
+        #if os(iOS)
+        #if targetEnvironment(macCatalyst)
+        return content.ub_ignoreSafeArea(edges: .bottom)
+        #else
+        return content // Legacy iOS should keep the safe-area inset intact.
+        #endif
+        #else
+        return content.ub_ignoreSafeArea(edges: .bottom)
+        #endif
     }
 }
 

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -65,7 +65,6 @@ struct HomeView: View {
                 .rootTabContentPadding(
                     proxy,
                     horizontal: 0,
-                    includeSafeArea: false,
                     tabBarGutter: proxy.compactAwareTabBarGutter
                 )
         }

--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -160,7 +160,24 @@ struct IncomeView: View {
     }
 
     private func contentBottomInset(using proxy: RootTabPageProxy) -> CGFloat {
-        proxy.safeAreaBottomInset + DS.Spacing.s
+        let tailSpacing = DS.Spacing.s
+
+        if capabilities.supportsOS26Translucency {
+            return tailSpacing
+        }
+
+        #if os(iOS)
+        #if targetEnvironment(macCatalyst)
+        return tailSpacing
+        #else
+        let horizontalSizeClass = proxy.layoutContext.horizontalSizeClass ?? .compact
+        let tabChromeHeight: CGFloat = horizontalSizeClass == .regular ? 50 : 49
+        let chromeAllowance = max(tabChromeHeight - proxy.safeAreaBottomInset, 0)
+        return tailSpacing + chromeAllowance
+        #endif
+        #else
+        return tailSpacing
+        #endif
     }
 
     private let landscapeLayoutMinimumWidth: CGFloat = 780
@@ -328,7 +345,6 @@ struct IncomeView: View {
             horizontal: horizontalInset,
             extraTop: DS.Spacing.s,
             extraBottom: contentBottomInset(using: proxy),
-            includeSafeArea: false,
             tabBarGutter: gutter
         )
         .frame(
@@ -364,7 +380,6 @@ struct IncomeView: View {
             horizontal: horizontalInset,
             extraTop: DS.Spacing.s,
             extraBottom: contentBottomInset(using: proxy),
-            includeSafeArea: false,
             tabBarGutter: gutter
         )
         .frame(
@@ -392,7 +407,6 @@ struct IncomeView: View {
                 horizontal: horizontalInset,
                 extraTop: DS.Spacing.s,
                 extraBottom: contentBottomInset(using: proxy),
-                includeSafeArea: false,
                 tabBarGutter: gutter
             )
         }

--- a/OffshoreBudgeting/Views/PresetsView.swift
+++ b/OffshoreBudgeting/Views/PresetsView.swift
@@ -121,7 +121,7 @@ struct PresetsView: View {
             proxy,
             horizontal: 0,
             extraTop: DS.Spacing.s,
-            includeSafeArea: false,
+            extraBottom: DS.Spacing.s,
             tabBarGutter: proxy.compactAwareTabBarGutter
         )
         // MARK: Data lifecycle

--- a/OffshoreBudgeting/Views/SettingsView.swift
+++ b/OffshoreBudgeting/Views/SettingsView.swift
@@ -276,7 +276,6 @@ struct SettingsView: View {
                 using: proxy,
                 tabBarGutter: tabBarGutter
             ),
-            includeSafeArea: false,
             tabBarGutter: tabBarGutter
         )
     }
@@ -376,19 +375,20 @@ struct SettingsView: View {
         tabBarGutter: RootTabPageProxy.TabBarGutter
     ) -> CGFloat {
         let base = horizontalSizeClass == .compact ? 0 : DS.Spacing.l
-        let scrollTailAllowance = DS.Spacing.l 
-        let tabChromeHeight: CGFloat = horizontalSizeClass == .compact ? 49 : 50
+        let scrollTailAllowance = DS.Spacing.l
         let gutter = proxy.tabBarGutterSpacing(tabBarGutter)
 
         if capabilities.supportsOS26Translucency {
             // On OS26 we respect safe area; no extra is required beyond minor spacing.
             return max(base - gutter, 0) + scrollTailAllowance
         } else {
-            // Legacy path: scaffold ignores the bottom safe area. Pad content by the
-            // visible chrome (tab bar height) plus safe-area inset so the last card
-            // remains fully visible above the opaque tab bar.
-            let required = tabChromeHeight + proxy.safeAreaBottomInset
-            return max(required + base - gutter, 0) + scrollTailAllowance
+            // Legacy path: ensure we account for devices where the safe-area inset
+            // is smaller than the visible tab chrome (e.g., classic home-button
+            // hardware). Add only the missing portion so modern devices avoid
+            // double-spacing.
+            let tabChromeHeight: CGFloat = horizontalSizeClass == .compact ? 49 : 50
+            let chromeAllowance = max(tabChromeHeight - proxy.safeAreaBottomInset, 0)
+            return max(base - gutter, 0) + scrollTailAllowance + chromeAllowance
         }
     }
 


### PR DESCRIPTION
## Summary
- stop ignoring the bottom safe area for legacy iOS tab scaffolds
- adjust root screen padding helpers so content still clears the tab bar
- keep modern OS 26 styling while adding legacy allowances only when needed

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e43b83ae58832caca42dd2750ccca5