### PR TITLE
Adjust root tab padding for legacy chrome

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -1701,12 +1701,12 @@ private enum BudgetListBottomInsetMetrics {
     static func bottomInset(for layoutContext: ResponsiveLayoutContext) -> CGFloat { 0 }
     #else
     private static let compactTabBarHeight: CGFloat = 49
-    private static let regularTabBarHeight: CGFloat = 49
+    private static let regularTabBarHeight: CGFloat = 50
 
     static func bottomInset(for layoutContext: ResponsiveLayoutContext) -> CGFloat {
         let safeArea = layoutContext.safeArea.bottom
-        let sizeClass = layoutContext.horizontalSizeClass ?? .compact
-        let tabBarHeight = sizeClass == .regular ? regularTabBarHeight : compactTabBarHeight
+        let horizontalSizeClass = layoutContext.horizontalSizeClass ?? .compact
+        let tabBarHeight = horizontalSizeClass == .regular ? regularTabBarHeight : compactTabBarHeight
         if safeArea >= tabBarHeight - 1 {
             return safeArea
         } else {

--- a/OffshoreBudgeting/Views/CardDetailView.swift
+++ b/OffshoreBudgeting/Views/CardDetailView.swift
@@ -605,12 +605,12 @@ private enum CardDetailListBottomInsetMetrics {
     // Match BudgetDetailsView behavior: ensure at least the tab bar height is
     // represented so the list always scrolls comfortably.
     private static let compactTabBarHeight: CGFloat = 49
-    private static let regularTabBarHeight: CGFloat = 49
+    private static let regularTabBarHeight: CGFloat = 50
 
     static func bottomInset(for layoutContext: ResponsiveLayoutContext) -> CGFloat {
         let safeAreaBottom = layoutContext.safeArea.bottom
-        let sizeClass = layoutContext.horizontalSizeClass ?? .compact
-        let tabBarHeight = sizeClass == .regular ? regularTabBarHeight : compactTabBarHeight
+        let horizontalSizeClass = layoutContext.horizontalSizeClass ?? .compact
+        let tabBarHeight = horizontalSizeClass == .regular ? regularTabBarHeight : compactTabBarHeight
         if safeAreaBottom >= tabBarHeight - 1 {
             return safeAreaBottom
         } else {

--- a/OffshoreBudgeting/Views/Components/RootTabPageScaffold.swift
+++ b/OffshoreBudgeting/Views/Components/RootTabPageScaffold.swift
@@ -147,7 +147,8 @@ struct RootTabPageScaffold<Header: View, Content: View>: View {
             spacing: spacing,
             combinedHeight: combinedHeight,
             availableHeight: availableHeight,
-            isScrollEnabled: isScrollEnabled
+            isScrollEnabled: isScrollEnabled,
+            platformCapabilities: platformCapabilities
         )
 
         Group {
@@ -310,6 +311,7 @@ struct RootTabPageProxy {
     let combinedHeight: CGFloat
     let availableHeight: CGFloat
     let isScrollEnabled: Bool
+    let platformCapabilities: PlatformCapabilities
 
     /// Controls the amount of vertical spacing inserted between tab content and the tab bar.
     enum TabBarGutter {
@@ -377,7 +379,7 @@ struct RootTabPageProxy {
     }
 
     var standardTabContentBottomPadding: CGFloat {
-        safeAreaBottomInset + tabBarGutterSpacing
+        tabContentBottomPadding()
     }
 
     func tabContentBottomPadding(
@@ -385,9 +387,16 @@ struct RootTabPageProxy {
         extraBottom: CGFloat = 0,
         tabBarGutter: TabBarGutter = .standard
     ) -> CGFloat {
-        let safeAreaContribution = includeSafeArea ? safeAreaBottomInset : 0
         let gutterSpacing = tabBarGutterSpacing(tabBarGutter)
-        return gutterSpacing + safeAreaContribution + extraBottom
+        if platformCapabilities.supportsOS26Translucency {
+            let safeAreaContribution = includeSafeArea ? safeAreaBottomInset : 0
+            return gutterSpacing + safeAreaContribution + extraBottom
+        } else {
+            // Classic chrome ignores the safe area so always include the visible
+            // tab bar height and bottom inset before layering on any caller
+            // provided spacing.
+            return gutterSpacing + legacyTabBarChromeBottomInset + extraBottom
+        }
     }
 
     func standardContentInsets(
@@ -424,6 +433,28 @@ extension RootTabPageProxy {
         if layoutContext.containerSize.width >= 600 { return RootTabHeaderLayout.defaultHorizontalPadding }
 
         return max(effectiveSafeAreaInsets.leading, DS.Spacing.s)
+    }
+
+    func resolvedSymmetricHorizontalInset() -> CGFloat {
+        resolvedSymmetricHorizontalInset(capabilities: platformCapabilities)
+    }
+
+    /// Returns the visible height of the classic tab bar chrome (opaque styles
+    /// on iOS ≤ 18) including the bottom safe-area inset so callers can space
+    /// content appropriately when the scaffold ignores the safe area.
+    var legacyTabBarChromeBottomInset: CGFloat {
+        guard !platformCapabilities.supportsOS26Translucency else { return 0 }
+        return legacyTabBarChromeHeight + safeAreaBottomInset
+    }
+
+    private var legacyTabBarChromeHeight: CGFloat {
+        guard !platformCapabilities.supportsOS26Translucency else { return 0 }
+
+        if let horizontalSizeClass = layoutContext.horizontalSizeClass, horizontalSizeClass == .regular {
+            return 50
+        }
+
+        return 49
     }
 }
 

--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -159,8 +159,8 @@ struct IncomeView: View {
         )
     }
 
-    private func contentBottomInset(using proxy: RootTabPageProxy) -> CGFloat {
-        proxy.safeAreaBottomInset + DS.Spacing.s
+    private func contentBottomInset(using _: RootTabPageProxy) -> CGFloat {
+        DS.Spacing.s
     }
 
     private let landscapeLayoutMinimumWidth: CGFloat = 780

--- a/OffshoreBudgeting/Views/SettingsView.swift
+++ b/OffshoreBudgeting/Views/SettingsView.swift
@@ -376,8 +376,7 @@ struct SettingsView: View {
         tabBarGutter: RootTabPageProxy.TabBarGutter
     ) -> CGFloat {
         let base = horizontalSizeClass == .compact ? 0 : DS.Spacing.l
-        let scrollTailAllowance = DS.Spacing.l 
-        let tabChromeHeight: CGFloat = horizontalSizeClass == .compact ? 49 : 50
+        let scrollTailAllowance = DS.Spacing.l
         let gutter = proxy.tabBarGutterSpacing(tabBarGutter)
 
         if capabilities.supportsOS26Translucency {
@@ -387,7 +386,7 @@ struct SettingsView: View {
             // Legacy path: scaffold ignores the bottom safe area. Pad content by the
             // visible chrome (tab bar height) plus safe-area inset so the last card
             // remains fully visible above the opaque tab bar.
-            let required = tabChromeHeight + proxy.safeAreaBottomInset
+            let required = proxy.legacyTabBarChromeBottomInset
             return max(required + base - gutter, 0) + scrollTailAllowance
         }
     }


### PR DESCRIPTION
## Summary
- pass platform capabilities through `RootTabPageProxy` and add a legacy tab-bar chrome helper that updates shared padding utilities
- rely on the scaffold-provided inset in Income and Settings, removing redundant safe-area math
- align card and budget detail list spacers with the updated classic tab-bar height

## Testing
- not run (iOS simulators unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e44131c96c832c9af6027993940df2