### PR TITLE
Adjust home toolbar glass transitions

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -210,6 +210,20 @@ struct HomeView: View {
         }
     }
 
+    private var addMenuGlassTransition: Any? {
+        guard capabilities.supportsOS26Translucency else {
+            return toolbarGlassTransition
+        }
+
+        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            guard !reduceMotion else { return toolbarGlassTransition }
+            let t: GlassEffectTransition = .materialize
+            return t
+        } else {
+            return toolbarGlassTransition
+        }
+    }
+
     private var periodAdjustmentAnimation: Animation {
         .spring(response: 0.34, dampingFraction: 0.78, blendDuration: 0.1)
     }
@@ -240,6 +254,7 @@ struct HomeView: View {
                     systemImage: "calendar",
                     glassNamespace: toolbarGlassNamespace,
                     glassID: HomeToolbarGlassIdentifiers.calendar,
+                    glassUnionID: HomeToolbarGlassIdentifiers.union,
                     glassTransition: toolbarGlassTransition,
                     background: .clear
                 )
@@ -249,6 +264,7 @@ struct HomeView: View {
                     systemImage: "calendar",
                     glassNamespace: toolbarGlassNamespace,
                     glassID: HomeToolbarGlassIdentifiers.calendar,
+                    glassUnionID: HomeToolbarGlassIdentifiers.union,
                     transition: toolbarGlassTransition
                 )
                 .accessibilityLabel(budgetPeriod.displayName)
@@ -276,7 +292,8 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
-                transition: toolbarGlassTransition
+                glassUnionID: HomeToolbarGlassIdentifiers.union,
+                transition: addMenuGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -296,7 +313,8 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
-                transition: toolbarGlassTransition
+                glassUnionID: HomeToolbarGlassIdentifiers.union,
+                transition: addMenuGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -315,6 +333,7 @@ struct HomeView: View {
                 systemImage: "ellipsis",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.options,
+                glassUnionID: HomeToolbarGlassIdentifiers.union,
                 transition: toolbarGlassTransition
             )
         }
@@ -342,6 +361,7 @@ struct HomeView: View {
                 symbolVariants: SymbolVariants.none,
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.options,
+                glassUnionID: HomeToolbarGlassIdentifiers.union,
                 transition: toolbarGlassTransition
             )
         }


### PR DESCRIPTION
## Summary
- add a dedicated transition helper so the add menu materializes on iOS 26
- align all home toolbar icons to share the same glass union identifier
- keep legacy toolbar behavior unchanged when Liquid Glass is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e45b99d438832c9650fbbd7a638800