### PR TITLE
Stabilize home toolbar glass unions

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -87,6 +87,7 @@ struct HomeView: View {
                             addExpenseToolbarMenu(for: active.id)
                         }
                     }
+                    .animation(nil, value: actionableSummaryForSelectedPeriod?.id)
                 } else {
                     // Legacy / older OS
                     if let periodSummary = actionableSummaryForSelectedPeriod {
@@ -240,6 +241,7 @@ struct HomeView: View {
                     systemImage: "calendar",
                     glassNamespace: toolbarGlassNamespace,
                     glassID: HomeToolbarGlassIdentifiers.calendar,
+                    glassUnionID: HomeGlassUnionID.main.rawValue,
                     glassTransition: toolbarGlassTransition,
                     background: .clear
                 )
@@ -249,6 +251,7 @@ struct HomeView: View {
                     systemImage: "calendar",
                     glassNamespace: toolbarGlassNamespace,
                     glassID: HomeToolbarGlassIdentifiers.calendar,
+                    glassUnionID: HomeGlassUnionID.main.rawValue,
                     transition: toolbarGlassTransition
                 )
                 .accessibilityLabel(budgetPeriod.displayName)
@@ -276,6 +279,7 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
+                glassUnionID: HomeGlassUnionID.main.rawValue,
                 transition: toolbarGlassTransition
             )
         }
@@ -296,6 +300,7 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
+                glassUnionID: HomeGlassUnionID.main.rawValue,
                 transition: toolbarGlassTransition
             )
         }
@@ -315,6 +320,7 @@ struct HomeView: View {
                 systemImage: "ellipsis",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.options,
+                glassUnionID: HomeGlassUnionID.main.rawValue,
                 transition: toolbarGlassTransition
             )
         }
@@ -342,6 +348,7 @@ struct HomeView: View {
                 symbolVariants: SymbolVariants.none,
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.options,
+                glassUnionID: HomeGlassUnionID.main.rawValue,
                 transition: toolbarGlassTransition
             )
         }
@@ -1034,7 +1041,11 @@ private enum HomeToolbarGlassIdentifiers {
     static let options = "home-toolbar.options"
     static let calendar = "home-toolbar.calendar"
     static let addExpense = "home-toolbar.add-expense"
-    static let union = "home-toolbar.union"
+}
+
+private enum HomeGlassUnionID: String {
+    case main = "home-toolbar.union.main"
+    case extras = "home-toolbar.union.extras"
 }
 
 private enum HomeHeaderOverviewMetrics {


### PR DESCRIPTION
## Summary
- add a HomeGlassUnionID enum and reuse it when wiring toolbar menu icons to the glass namespace
- apply a nil animation to the iOS 26 GlassEffectContainer to prevent unwanted transitions during period changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5426dd66c832c9610b58c875f6045