### PR TITLE
Restore budget summary flag for toolbar animation

### DIFF
--- a/OffshoreBudgeting/View Models/BudgetDetailsViewModel.swift
+++ b/OffshoreBudgeting/View Models/BudgetDetailsViewModel.swift
@@ -158,6 +158,7 @@ final class BudgetDetailsViewModel: ObservableObject {
             variableExpensesTotal: variableTotal,
             plannedExpensesPlannedTotal: plannedPlanned,
             plannedExpensesActualTotal: plannedActual,
+            hasAtLeastOneBudget: true,
             potentialIncomeTotal: incomeTotals.planned,
             actualIncomeTotal: incomeTotals.actual
         )

--- a/OffshoreBudgeting/View Models/HomeViewModel.swift
+++ b/OffshoreBudgeting/View Models/HomeViewModel.swift
@@ -85,6 +85,7 @@ struct BudgetSummary: Identifiable, Equatable, Sendable {
     }
 
     // MARK: Convenience
+    let hasAtLeastOneBudget: Bool
     var periodString: String {
         let f = DateFormatter()
         f.dateFormat = "MMM d, yyyy"
@@ -466,6 +467,7 @@ final class HomeViewModel: ObservableObject {
             variableExpensesTotal: variableTotal,
             plannedExpensesPlannedTotal: plannedExpensesPlannedTotal,
             plannedExpensesActualTotal: plannedExpensesActualTotal,
+            hasAtLeastOneBudget: true,
             potentialIncomeTotal: potentialIncomeTotal,
             actualIncomeTotal: actualIncomeTotal
         )


### PR DESCRIPTION
## Summary
- add the `hasAtLeastOneBudget` flag back onto `BudgetSummary` so new toolbar logic compiles
- ensure both home and detail view models populate the flag when constructing summaries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e544f2b5ec832cb1d86ef0adb4c5d2