### PR TITLE
Prevent OS26 toolbar animation resets

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -87,6 +87,7 @@ struct HomeView: View {
                             addExpenseToolbarMenu(for: active.id)
                         }
                     }
+                    .animation(nil, value: actionableSummaryForSelectedPeriod?.id)
                 } else {
                     // Legacy / older OS
                     if let periodSummary = actionableSummaryForSelectedPeriod {


### PR DESCRIPTION
## Summary
- stop the OS26 glass toolbar container from reanimating when the selected period changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e54847fcbc832c9ac75b582df9da54