### PR TITLE
Guard hasActiveBudget state transitions

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -110,11 +110,16 @@ struct HomeView: View {
         }
         .onAppear { hasActiveBudget = actionableSummaryForSelectedPeriod != nil }
         .ub_onChange(of: actionableSummaryForSelectedPeriod?.id) { _ in
-            let newValue = actionableSummaryForSelectedPeriod != nil
+            let newHasActiveBudget = actionableSummaryForSelectedPeriod != nil
+            guard newHasActiveBudget != hasActiveBudget else {
+                hasActiveBudget = newHasActiveBudget
+                return
+            }
+
             if capabilities.supportsOS26Translucency && !reduceMotion {
-                withAnimation(periodAdjustmentAnimation) { hasActiveBudget = newValue }
+                withAnimation(periodAdjustmentAnimation) { hasActiveBudget = newHasActiveBudget }
             } else {
-                hasActiveBudget = newValue
+                hasActiveBudget = newHasActiveBudget
             }
         }
         // Temporarily disable automatic refresh on every Core Data save to


### PR DESCRIPTION
## Summary
- compute the new hasActiveBudget value inside the ub_onChange handler
- skip animated transitions when the value is unchanged while still updating the binding
- keep animations limited to real toggles and fall back to direct assignment otherwise

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5495dcbc8832c8d3e8c8a7e114600