### PR TITLE
Align plus expense menu with primary glass union

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -282,7 +282,7 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
-                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.extras.rawValue : nil,
+                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
                 transition: toolbarGlassTransition
             )
         }
@@ -303,7 +303,7 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
-                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.extras.rawValue : nil,
+                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
                 transition: toolbarGlassTransition
             )
         }


### PR DESCRIPTION
## Summary
- update the Home toolbar plus menu to join the main glass union so it animates with the other controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5500d8d70832cbeb1d1a80b3c13fb