### PR TITLE
Adjust glass union for add expense toolbar

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -282,7 +282,7 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
-                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.extras.rawValue : nil,
+                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
                 transition: toolbarGlassTransition
             )
         }
@@ -303,7 +303,7 @@ struct HomeView: View {
                 systemImage: "plus",
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
-                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.extras.rawValue : nil,
+                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
                 transition: toolbarGlassTransition
             )
         }


### PR DESCRIPTION
## Summary
- ensure both add expense toolbar menus share the main glass union when translucency is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5510518e4832c8a0d726f3c36f315