### PR TITLE
Delay hasActiveBudget updates until period load completes

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -43,6 +43,7 @@ struct HomeView: View {
     @State private var isPresentingManageCategories: Bool = false
     @Namespace private var toolbarGlassNamespace
     @State private var hasActiveBudget: Bool = false
+    @State private var lastLoadedSelection: Date?
 
     // MARK: Body
     @EnvironmentObject private var themeManager: ThemeManager
@@ -110,7 +111,22 @@ struct HomeView: View {
             vm.startIfNeeded()
         }
         .onAppear { hasActiveBudget = actionableSummaryForSelectedPeriod != nil }
+        .ub_onChange(of: vm.state) { newState in
+            switch newState {
+            case .empty:
+                lastLoadedSelection = vm.selectedDate
+            case .loaded(_):
+                lastLoadedSelection = vm.selectedDate
+            case .initial, .loading:
+                lastLoadedSelection = nil
+            }
+        }
         .ub_onChange(of: actionableSummaryForSelectedPeriod?.id) { _ in
+            guard let lastLoadedSelection,
+                  Calendar.current.isDate(lastLoadedSelection, inSameDayAs: vm.selectedDate) else {
+                return
+            }
+
             let newHasActiveBudget = actionableSummaryForSelectedPeriod != nil
             guard newHasActiveBudget != hasActiveBudget else { return }
 


### PR DESCRIPTION
## Summary
- add state to HomeView to remember the last selection with finished summaries
- update onChange handlers to wait for the current selection to load before animating hasActiveBudget

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e551ef0e04832ca3e40e72831a2978