### PR TITLE
Adopt glass button components across toolbars and CTAs

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -984,22 +984,9 @@ private struct PlannedListFR: View {
     // MARK: Local: Add action button with OS-aware styling
     @ViewBuilder
     private func addActionButton(title: String, action: @escaping () -> Void) -> some View {
-        Group {
-            if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-                Button(action: action) {
-                    budgetDetailsCTAButtonLabel(title)
-                        .foregroundStyle(.primary)
-                }
-                .buttonStyle(.glass)
-                .tint(themeManager.selectedTheme.resolvedTint)
-            } else {
-                Button(action: action) {
-                    budgetDetailsCTAButtonLabel(title)
-                }
-                .buttonStyle(.plain)
-            }
+        GlassCTAButton(fillHorizontally: true, action: action) {
+            budgetDetailsCTAButtonLabel(title)
         }
-        .frame(maxWidth: .infinity)
     }
 
     @ViewBuilder

--- a/OffshoreBudgeting/Views/CardDetailView.swift
+++ b/OffshoreBudgeting/Views/CardDetailView.swift
@@ -409,7 +409,7 @@ struct CardDetailView: View {
         #endif
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Done") { onDone() }
+                    GlassTextButton("Done") { onDone() }
                         .keyboardShortcut(.escape, modifiers: [])
                 }
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
@@ -418,7 +418,7 @@ struct CardDetailView: View {
                             .textFieldStyle(.roundedBorder)
                             .frame(maxWidth: 200)
                             .focused($isSearchFieldFocused)
-                        Button("Cancel") {
+                        GlassTextButton("Cancel", role: .cancel) {
                             withAnimation {
                                 isSearchActive = false
                                 viewModel.searchText = ""
@@ -426,13 +426,19 @@ struct CardDetailView: View {
                             }
                         }
                     } else {
-                        IconOnlyButton(systemName: "magnifyingglass") {
-                            withAnimation { isSearchActive = true }
-                            isSearchFieldFocused = true
-                        }
-                        IconOnlyButton(systemName: "pencil") {
-                            onEdit()
-                        }
+                        RootHeaderIconActionButton(
+                            systemImage: "magnifyingglass",
+                            accessibilityLabel: "Search",
+                            action: {
+                                withAnimation { isSearchActive = true }
+                                isSearchFieldFocused = true
+                            }
+                        )
+                        RootHeaderIconActionButton(
+                            systemImage: "pencil",
+                            accessibilityLabel: "Edit",
+                            action: { onEdit() }
+                        )
                         // Add Expense menu (Planned or Variable) — keep as the rightmost control
                         Menu {
                             Button("Add Planned Expense") { isPresentingAddPlanned = true }
@@ -541,33 +547,6 @@ private struct ExpenseRow: View {
         }
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
-    }
-}
-
-// MARK: - Shared Toolbar Icon
-private struct IconOnlyButton: View {
-    let systemName: String
-    var action: () -> Void
-    @EnvironmentObject private var themeManager: ThemeManager
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: 18, weight: .semibold))
-                .symbolRenderingMode(.monochrome)
-                .foregroundStyle(themeManager.selectedTheme.accent)
-                .imageScale(.medium)
-                .padding(.horizontal, 2)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(Text(label))
-    }
-    private var label: String {
-        switch systemName {
-        case "magnifyingglass": return "Search"
-        case "pencil": return "Edit"
-        default: return "Action"
-        }
     }
 }
 

--- a/OffshoreBudgeting/Views/CardsView.swift
+++ b/OffshoreBudgeting/Views/CardsView.swift
@@ -129,17 +129,17 @@ struct CardsView: View {
     }
 
     private var addActionToolbarButton: some View {
-        Button {
-            if selectedCardStableID == nil {
-                isPresentingAddCard = true
-            } else {
-                isPresentingAddExpense = true
+        RootHeaderIconActionButton(
+            systemImage: "plus",
+            accessibilityLabel: selectedCardStableID == nil ? "Add Card" : "Add Expense",
+            action: {
+                if selectedCardStableID == nil {
+                    isPresentingAddCard = true
+                } else {
+                    isPresentingAddExpense = true
+                }
             }
-        } label: {
-            Image(systemName: "plus")
-                //.imageScale(.medium)
-        }
-        .accessibilityLabel(selectedCardStableID == nil ? "Add Card" : "Add Expense")
+        )
     }
 
     // MARK: - Content View (Type-Safe)

--- a/OffshoreBudgeting/Views/Components/GlassCTAButton.swift
+++ b/OffshoreBudgeting/Views/Components/GlassCTAButton.swift
@@ -11,6 +11,7 @@ struct GlassCTAButton<Label: View>: View {
 
     private let maxWidth: CGFloat?
     private let fillHorizontally: Bool
+    private let tintOverride: Color?
     private let action: () -> Void
     private let labelBuilder: () -> Label
     private let fallbackAppearance: TranslucentButtonStyle.Appearance
@@ -21,11 +22,13 @@ struct GlassCTAButton<Label: View>: View {
         fillHorizontally: Bool = false,
         fallbackAppearance: TranslucentButtonStyle.Appearance = .tinted,
         fallbackMetrics: TranslucentButtonStyle.Metrics = .standard,
+        tint: Color? = nil,
         action: @escaping () -> Void,
         @ViewBuilder label: @escaping () -> Label
     ) {
         self.maxWidth = maxWidth
         self.fillHorizontally = fillHorizontally
+        self.tintOverride = tint
         self.action = action
         self.labelBuilder = label
         self.fallbackAppearance = fallbackAppearance
@@ -47,7 +50,7 @@ struct GlassCTAButton<Label: View>: View {
         }
         .buttonStyle(
             TranslucentButtonStyle(
-                tint: fallbackTint,
+                tint: resolvedFallbackTint,
                 metrics: resolvedFallbackMetrics,
                 appearance: fallbackAppearance
             )
@@ -61,7 +64,7 @@ struct GlassCTAButton<Label: View>: View {
                 buttonLabel()
             }
             .buttonStyle(.glass)
-            .tint(glassTint)
+            .tint(resolvedGlassTint)
             .onAppear {
                 capabilities.qaLogLiquidGlassDecision(component: "GlassCTAButton", path: "glass")
             }
@@ -83,12 +86,12 @@ struct GlassCTAButton<Label: View>: View {
             .frame(maxWidth: fillHorizontally ? .infinity : nil, alignment: .center)
     }
 
-    private var fallbackTint: Color {
-        themeManager.selectedTheme.resolvedTint
+    private var resolvedFallbackTint: Color {
+        tintOverride ?? themeManager.selectedTheme.resolvedTint
     }
 
-    private var glassTint: Color {
-        themeManager.selectedTheme.glassPalette.accent
+    private var resolvedGlassTint: Color {
+        tintOverride ?? themeManager.selectedTheme.glassPalette.accent
     }
 
     private var glassLabelForeground: Color {

--- a/OffshoreBudgeting/Views/Components/GlassTextButton.swift
+++ b/OffshoreBudgeting/Views/Components/GlassTextButton.swift
@@ -15,6 +15,7 @@ struct GlassTextButton<Label: View>: View {
     private let maxWidth: CGFloat?
     private let alignment: Alignment
     private let contentStyle: LabelContentStyle
+    private let role: ButtonRole?
     private let action: () -> Void
     private let labelBuilder: () -> Label
 
@@ -23,6 +24,7 @@ struct GlassTextButton<Label: View>: View {
         maxWidth: CGFloat? = nil,
         alignment: Alignment = .center,
         contentStyle: LabelContentStyle = .text,
+        role: ButtonRole? = nil,
         action: @escaping () -> Void,
         @ViewBuilder label: @escaping () -> Label
     ) {
@@ -30,6 +32,7 @@ struct GlassTextButton<Label: View>: View {
         self.maxWidth = maxWidth
         self.alignment = alignment
         self.contentStyle = contentStyle
+        self.role = role
         self.action = action
         self.labelBuilder = label
     }
@@ -37,7 +40,7 @@ struct GlassTextButton<Label: View>: View {
     var body: some View {
         Group {
             if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-                Button(action: action) {
+                button(role: role) {
                     buttonLabel()
                 }
                 .buttonStyle(.glass)
@@ -47,7 +50,7 @@ struct GlassTextButton<Label: View>: View {
                     capabilities.qaLogLiquidGlassDecision(component: "GlassTextButton", path: "glass")
                 }
             } else {
-                Button(action: action) {
+                button(role: role) {
                     buttonLabel()
                 }
                 .buttonStyle(.plain)
@@ -59,6 +62,19 @@ struct GlassTextButton<Label: View>: View {
         }
         .frame(maxWidth: maxWidth, alignment: alignment)
         .frame(width: width, alignment: alignment)
+    }
+
+    @ViewBuilder
+    private func button<Content: View>(role: ButtonRole?, @ViewBuilder content: () -> Content) -> some View {
+        if let role {
+            Button(role: role, action: action) {
+                content()
+            }
+        } else {
+            Button(action: action) {
+                content()
+            }
+        }
     }
 
     // MARK: - Label Styling
@@ -122,6 +138,7 @@ extension GlassTextButton where Label == Text {
         maxWidth: CGFloat? = nil,
         alignment: Alignment = .center,
         contentStyle: LabelContentStyle = .text,
+        role: ButtonRole? = nil,
         action: @escaping () -> Void
     ) {
         self.init(
@@ -129,6 +146,7 @@ extension GlassTextButton where Label == Text {
             maxWidth: maxWidth,
             alignment: alignment,
             contentStyle: contentStyle,
+            role: role,
             action: action
         ) {
             Text(titleKey)
@@ -141,6 +159,7 @@ extension GlassTextButton where Label == Text {
         maxWidth: CGFloat? = nil,
         alignment: Alignment = .center,
         contentStyle: LabelContentStyle = .text,
+        role: ButtonRole? = nil,
         action: @escaping () -> Void
     ) {
         self.init(
@@ -148,6 +167,7 @@ extension GlassTextButton where Label == Text {
             maxWidth: maxWidth,
             alignment: alignment,
             contentStyle: contentStyle,
+            role: role,
             action: action
         ) {
             Text(title)

--- a/OffshoreBudgeting/Views/CustomRecurrenceEditorView.swift
+++ b/OffshoreBudgeting/Views/CustomRecurrenceEditorView.swift
@@ -102,17 +102,16 @@ struct CustomRecurrenceEditorView: View {
                         .navigationTitle("Custom Recurrence")
                         .toolbar {
                             ToolbarItem(placement: .cancellationAction) {
-                                Button("Cancel") {
+                                GlassTextButton("Cancel", role: .cancel) {
                                     onCancel()
                                     dismiss()
                                 }
                             }
                             ToolbarItem(placement: .confirmationAction) {
-                                Button("Save") {
+                                GlassTextButton("Save") {
                                     onSave(draft)
                                     dismiss()
                                 }
-                                .font(.headline)
                             }
                         }
                 }
@@ -122,17 +121,16 @@ struct CustomRecurrenceEditorView: View {
                         .navigationTitle("Custom Recurrence")
                         .toolbar {
                             ToolbarItem(placement: .cancellationAction) {
-                                Button("Cancel") {
+                                GlassTextButton("Cancel", role: .cancel) {
                                     onCancel()
                                     dismiss()
                                 }
                             }
                             ToolbarItem(placement: .confirmationAction) {
-                                Button("Save") {
+                                GlassTextButton("Save") {
                                     onSave(draft)
                                     dismiss()
                                 }
-                                .font(.headline)
                             }
                         }
                 }

--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -88,18 +88,16 @@ struct EditSheetScaffold<SheetContent: View>: View {
                     .toolbar {
                         // Cancel
                         ToolbarItem(placement: .cancellationAction) {
-                            Button(cancelButtonTitle) {
+                            GlassTextButton(cancelButtonTitle, role: .cancel) {
                                 onCancel?()
                                 dismiss()
                             }
-                            .tint(themeManager.selectedTheme.resolvedTint)
                         }
                         // Save
                         ToolbarItem(placement: .confirmationAction) {
-                            Button(saveButtonTitle) {
+                            GlassTextButton(saveButtonTitle) {
                                 if onSave() { dismiss() }
                             }
-                            .tint(themeManager.selectedTheme.resolvedTint)
                             .disabled(!isSaveEnabled)
                         }
                     }

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -463,28 +463,10 @@ struct HomeView: View {
                 VStack(alignment: .leading, spacing: DS.Spacing.m) {
                     // Always-offer primary CTA when no budget exists so users can
                     // quickly create a budget or add expenses for this period.
-                    Group {
-                        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-                            Button(action: addExpenseCTAAction) {
-                                Label(addExpenseCTATitle, systemImage: "plus")
-                                    .font(.system(size: 17, weight: .semibold, design: .rounded))
-                                    .frame(
-                                maxWidth: .infinity,
-                                minHeight: HomeHeaderOverviewMetrics.categoryControlHeight
-                            )
-                                    .frame(minHeight: 44)
-                            }
-                            .buttonStyle(.glass)
-                            .tint(themeManager.selectedTheme.resolvedTint)
-                        } else {
-                            Button(action: addExpenseCTAAction) {
-                                Label(addExpenseCTATitle, systemImage: "plus")
-                                    .font(.system(size: 17, weight: .semibold, design: .rounded))
-                                    .frame(maxWidth: .infinity)
-                                    .frame(minHeight: 44)
-                            }
-                            .buttonStyle(.plain)
-                        }
+                    GlassCTAButton(fillHorizontally: true, action: addExpenseCTAAction) {
+                        Label(addExpenseCTATitle, systemImage: "plus")
+                            .frame(maxWidth: .infinity)
+                            .frame(minHeight: max(44, HomeHeaderOverviewMetrics.categoryControlHeight))
                     }
                     .accessibilityIdentifier("emptyPeriodAddExpenseCTA")
                     .frame(maxWidth: .infinity)

--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -178,11 +178,12 @@ struct IncomeView: View {
     }
 
     private var addIncomeButton: some View {
-        Button(action: { beginAddingIncome() }) {
-            Image(systemName: "plus")
-        }
-        .accessibilityLabel("Add Income")
-        .accessibilityIdentifier("add_income_button")
+        RootHeaderIconActionButton(
+            systemImage: "plus",
+            accessibilityLabel: "Add Income",
+            accessibilityIdentifier: "add_income_button",
+            action: { beginAddingIncome() }
+        )
     }
 
     // MARK: Calendar

--- a/OffshoreBudgeting/Views/ManageBudgetCardsSheet.swift
+++ b/OffshoreBudgeting/Views/ManageBudgetCardsSheet.swift
@@ -35,7 +35,12 @@ struct ManageBudgetCardsSheet: View {
             }
             .navigationTitle("Manage Cards")
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss(); onDone() } }
+                ToolbarItem(placement: .cancellationAction) {
+                    GlassTextButton("Done") {
+                        dismiss()
+                        onDone()
+                    }
+                }
             }
         }
     }

--- a/OffshoreBudgeting/Views/ManageBudgetPresetsSheet.swift
+++ b/OffshoreBudgeting/Views/ManageBudgetPresetsSheet.swift
@@ -45,7 +45,9 @@ struct ManageBudgetPresetsSheet: View {
             .navigationTitle("Budget Presets")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Done", action: dismissAndComplete)
+                    GlassTextButton("Done") {
+                        dismissAndComplete()
+                    }
                 }
             }
             .onAppear(perform: loadAssignments)

--- a/OffshoreBudgeting/Views/OnboardingView.swift
+++ b/OffshoreBudgeting/Views/OnboardingView.swift
@@ -487,14 +487,16 @@ private struct OnboardingPrimaryButton: View {
     let action: () -> Void
 
     @EnvironmentObject private var themeManager: ThemeManager
-    @Environment(\.platformCapabilities) private var capabilities
 
     var body: some View {
-        Button(action: action) {
+        GlassCTAButton(
+            fillHorizontally: true,
+            tint: themeManager.selectedTheme.resolvedTint,
+            action: action
+        ) {
             Text(title)
-                .frame(maxWidth: .infinity)
         }
-        .modifier(PrimaryButtonStyleAdapter(tint: themeManager.selectedTheme.resolvedTint, capabilities: capabilities))
+        .frame(minHeight: 44)
     }
 }
 
@@ -503,57 +505,17 @@ private struct OnboardingSecondaryButton: View {
     let action: () -> Void
 
     @EnvironmentObject private var themeManager: ThemeManager
-    @Environment(\.platformCapabilities) private var capabilities
 
     var body: some View {
-        Button(action: action) {
+        GlassCTAButton(
+            fillHorizontally: true,
+            fallbackAppearance: .neutral,
+            tint: themeManager.selectedTheme.resolvedTint,
+            action: action
+        ) {
             Text(title)
-                .frame(maxWidth: .infinity)
         }
-        .modifier(SecondaryButtonStyleAdapter(tint: themeManager.selectedTheme.resolvedTint, capabilities: capabilities))
-    }
-}
-
-// MARK: - Button Style Adapters (OS26 Glass vs Legacy)
-private struct PrimaryButtonStyleAdapter: ViewModifier {
-    let tint: Color
-    let capabilities: PlatformCapabilities
-
-    func body(content: Content) -> some View {
-        Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-                content
-                    .frame(minHeight: 44)
-                    .buttonStyle(.glass)
-                    .tint(tint)
-                    .controlSize(.large)
-            } else {
-                content
-                    .frame(minHeight: 44)
-                    .buttonStyle(TranslucentButtonStyle(tint: tint))
-            }
-        }
-    }
-}
-
-private struct SecondaryButtonStyleAdapter: ViewModifier {
-    let tint: Color
-    let capabilities: PlatformCapabilities
-
-    func body(content: Content) -> some View {
-        Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-                content
-                    .frame(minHeight: 44)
-                    .buttonStyle(.glass)
-                    .tint(tint)
-                    .controlSize(.large)
-            } else {
-                content
-                    .frame(minHeight: 44)
-                    .buttonStyle(OnboardingSecondaryButtonStyle(tint: tint))
-            }
-        }
+        .frame(minHeight: 44)
     }
 }
 
@@ -600,61 +562,6 @@ private struct OnboardingButtonRow: View {
             OnboardingPrimaryButton(title: configuration.title, action: configuration.action)
         case .secondary:
             OnboardingSecondaryButton(title: configuration.title, action: configuration.action)
-        }
-    }
-}
-
-private struct OnboardingSecondaryButtonStyle: ButtonStyle {
-    @Environment(\.platformCapabilities) private var capabilities
-
-    var tint: Color
-
-    func makeBody(configuration: Configuration) -> some View {
-        let radius: CGFloat = 26
-
-        return configuration.label
-            .font(.headline)
-            .foregroundStyle(tint)
-            .padding(.vertical, DS.Spacing.m)
-            .padding(.horizontal, DS.Spacing.l)
-            .frame(maxWidth: .infinity)
-            .contentShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
-            .background(background(isPressed: configuration.isPressed, radius: radius))
-            .overlay(border(radius: radius, isPressed: configuration.isPressed))
-            .overlay(highlight(radius: radius))
-            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
-            .animation(.spring(response: 0.32, dampingFraction: 0.72), value: configuration.isPressed)
-    }
-
-    @ViewBuilder
-    private func background(isPressed: Bool, radius: CGFloat) -> some View {
-        if capabilities.supportsOS26Translucency, #available(iOS 15.0, macCatalyst 16.0, *) {
-            RoundedRectangle(cornerRadius: radius, style: .continuous)
-                .fill(tint.opacity(isPressed ? 0.2 : 0.14))
-                .background(
-                    RoundedRectangle(cornerRadius: radius, style: .continuous)
-                        .fill(.ultraThinMaterial)
-                )
-                .compositingGroup()
-        } else {
-            RoundedRectangle(cornerRadius: radius, style: .continuous)
-                .fill(tint.opacity(isPressed ? 0.18 : 0.12))
-        }
-    }
-
-    private func border(radius: CGFloat, isPressed: Bool) -> some View {
-        RoundedRectangle(cornerRadius: radius, style: .continuous)
-            .stroke(tint.opacity(isPressed ? 0.6 : 0.45), lineWidth: 1.5)
-    }
-
-    @ViewBuilder
-    private func highlight(radius: CGFloat) -> some View {
-        if capabilities.supportsOS26Translucency {
-            RoundedRectangle(cornerRadius: radius, style: .continuous)
-                .stroke(Color.white.opacity(0.22), lineWidth: 1)
-                .blendMode(.screen)
-        } else {
-            EmptyView()
         }
     }
 }

--- a/OffshoreBudgeting/Views/PresetBudgetAssignmentSheet.swift
+++ b/OffshoreBudgeting/Views/PresetBudgetAssignmentSheet.swift
@@ -58,28 +58,30 @@ struct PresetBudgetAssignmentSheet: View {
                 // Cross-platform placements:
                 #if os(iOS)
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
+                    GlassTextButton("Cancel", role: .cancel) {
+                        dismiss()
+                    }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") {
+                    GlassTextButton("Done") {
                         saveContext()
                         onChangesCommitted?()
                         dismiss()
                     }
-                    .font(.headline)
                 }
                 #else
                 // macOS fallback
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    GlassTextButton("Cancel", role: .cancel) {
+                        dismiss()
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
+                    GlassTextButton("Done") {
                         saveContext()
                         onChangesCommitted?()
                         dismiss()
                     }
-                    .font(.headline)
                 }
                 #endif
             }

--- a/OffshoreBudgeting/Views/PresetsView.swift
+++ b/OffshoreBudgeting/Views/PresetsView.swift
@@ -169,10 +169,11 @@ struct PresetsView: View {
     }
 
     private var addPresetToolbarButton: some View {
-        Button(action: { isPresentingAddSheet = true }) {
-            Image(systemName: "plus")
-        }
-        .accessibilityLabel("Add Preset Planned Expense")
+        RootHeaderIconActionButton(
+            systemImage: "plus",
+            accessibilityLabel: "Add Preset Planned Expense",
+            action: { isPresentingAddSheet = true }
+        )
     }
 
     // MARK: - Actions

--- a/OffshoreBudgeting/Views/UBEmptyState.swift
+++ b/OffshoreBudgeting/Views/UBEmptyState.swift
@@ -24,7 +24,6 @@ import UIKit
 struct UBEmptyState: View {
 
     @Environment(\.isOnboardingPresentation) private var isOnboardingPresentation
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.platformCapabilities) private var capabilities
     @EnvironmentObject private var themeManager: ThemeManager
 
@@ -118,82 +117,18 @@ struct UBEmptyState: View {
     // MARK: Primary Button Helpers
     @ViewBuilder
     private func primaryButton(title: String, action: @escaping () -> Void) -> some View {
-        let fallbackTint = isOnboardingPresentation ? onboardingTint : primaryButtonTint
-        let glassTint = isOnboardingPresentation ? onboardingTint : primaryButtonGlassTint
-
-        glassPrimaryButton(
-            title: title,
-            fallbackTint: fallbackTint,
-            glassTint: glassTint,
+        GlassCTAButton(
+            maxWidth: 320,
+            tint: primaryButtonTintOverride,
             action: action
-        )
-    }
-
-    @ViewBuilder
-    private func legacyPrimaryButton(title: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            primaryButtonLabel(title: title)
-        }
-        .buttonStyle(.plain) // flat/plain (no rounded background on legacy)
-        .tint(primaryButtonTint)
-    }
-
-    @ViewBuilder
-    private func primaryButtonLabel(title: String) -> some View {
-        Label(title, systemImage: "plus")
-            .labelStyle(.titleAndIcon)
-            .foregroundStyle(primaryButtonForegroundColor())
-    }
-
-    @ViewBuilder
-    private func glassPrimaryButton(
-        title: String,
-        fallbackTint: Color,
-        glassTint: Color,
-        action: @escaping () -> Void
-    ) -> some View {
-        if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-            glassStyledPrimaryButton(title: title, glassTint: glassTint, action: action)
-        } else {
-            legacyPrimaryButton(title: title, action: action)
-        }
-    }
-
-    @available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *)
-    @ViewBuilder
-    private func glassStyledPrimaryButton(
-        title: String,
-        glassTint: Color,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
+        ) {
             Label(title, systemImage: "plus")
                 .labelStyle(.titleAndIcon)
-                .font(.system(size: 17, weight: .semibold, design: .rounded))
-                .foregroundStyle(primaryButtonForegroundColor())
-                .padding(.horizontal, DS.Spacing.xl)
-                .padding(.vertical, DS.Spacing.m)
         }
-        .tint(glassTint)
-        .buttonStyle(.glass)
-        .frame(maxWidth: 320)
     }
 
     @Environment(\.verticalSizeClass) private var verticalSizeClass
-    private func primaryButtonForegroundColor(isTintedBackground: Bool = false) -> Color {
-        switch colorScheme {
-        case .light:
-            return .black
-        default:
-            return isTintedBackground ? .white : .primary
-        }
-    }
-
-    private var primaryButtonTint: Color {
-        themeManager.selectedTheme.resolvedTint
-    }
-
-    private var primaryButtonGlassTint: Color {
-        themeManager.selectedTheme.glassPalette.accent
+    private var primaryButtonTintOverride: Color? {
+        isOnboardingPresentation ? onboardingTint : nil
     }
 }


### PR DESCRIPTION
## Summary
- add button role support to `GlassTextButton` and tint overrides to `GlassCTAButton` so new glass components fit toolbar and CTA use cases
- replace toolbar icon and text buttons in key views with `RootHeaderIconActionButton` and `GlassTextButton` for consistent accessibility and styling
- migrate block-style CTAs in budget, home, onboarding, and empty states to `GlassCTAButton` to preserve layout while adopting glass treatment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e572c62548832c8d874c63679d2ca6