### PR TITLE
Prevent add expense glass button morphing when budgets change

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -99,7 +99,7 @@ struct HomeView: View {
 
                     calendarToolbarMenu()
 
-                    if let active = actionableSummaryForSelectedPeriod {
+                    if hasActiveBudget, let active = actionableSummaryForSelectedPeriod {
                         addExpenseToolbarMenu(for: active.id)
                     }
                 }
@@ -214,6 +214,19 @@ struct HomeView: View {
         }
     }
 
+    private var addExpenseGlassTransition: Any? {
+        guard capabilities.supportsOS26Translucency else {
+            return nil
+        }
+
+        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            let t: GlassEffectTransition = reduceMotion ? .identity : .materialize
+            return t
+        } else {
+            return nil
+        }
+    }
+
     private var periodAdjustmentAnimation: Animation {
         .spring(response: 0.34, dampingFraction: 0.78, blendDuration: 0.1)
     }
@@ -283,7 +296,7 @@ struct HomeView: View {
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
                 glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                transition: toolbarGlassTransition
+                transition: addExpenseGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -304,7 +317,7 @@ struct HomeView: View {
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
                 glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                transition: toolbarGlassTransition
+                transition: addExpenseGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())


### PR DESCRIPTION
## Summary
- ensure the add-expense toolbar control uses a materialize glass transition instead of matched geometry so the glass container stays stable between budgets
- gate the legacy toolbar menu behind the cached active-budget flag to avoid reintroducing the control during rapid period changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e59c430160832c944f373b99095848