### PR TITLE
Adjust Home toolbar glass transitions

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -88,6 +88,7 @@ struct HomeView: View {
                                 .transition(.opacity.combined(with: .scale(scale: 0.95)))
                         }
                     }
+                    .animation(nil, value: hasActiveBudget)
                     .animation(nil, value: actionableSummaryForSelectedPeriod?.id)
                 } else {
                     // Legacy / older OS
@@ -214,6 +215,18 @@ struct HomeView: View {
         }
     }
 
+    private var addExpenseGlassTransition: Any? {
+        guard capabilities.supportsOS26Translucency else {
+            return nil
+        }
+
+        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            return GlassEffectTransition.identity
+        } else {
+            return nil
+        }
+    }
+
     private var periodAdjustmentAnimation: Animation {
         .spring(response: 0.34, dampingFraction: 0.78, blendDuration: 0.1)
     }
@@ -283,7 +296,7 @@ struct HomeView: View {
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
                 glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                transition: toolbarGlassTransition
+                transition: addExpenseGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -304,7 +317,7 @@ struct HomeView: View {
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
                 glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                transition: toolbarGlassTransition
+                transition: addExpenseGlassTransition
             )
         }
         .modifier(HideMenuIndicatorIfPossible())


### PR DESCRIPTION
## Summary
- disable implicit glass container animations when the Add Expense action toggles
- introduce an identity glass transition for the Add Expense menu so the glass capsule stays stable across budgets
- ensure the add-expense menu uses the identity transition on all variants

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e59c430160832c944f373b99095848