### PR TITLE
Stabilize Home toolbar glass add control on iOS 26

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -83,10 +83,7 @@ struct HomeView: View {
 
                         calendarToolbarMenu()
 
-                        if hasActiveBudget, let active = actionableSummaryForSelectedPeriod {
-                            addExpenseToolbarMenu(for: active.id)
-                                .transition(.opacity.combined(with: .scale(scale: 0.95)))
-                        }
+                        addExpenseToolbarGlassControl(for: actionableSummaryForSelectedPeriod)
                     }
                     .animation(nil, value: actionableSummaryForSelectedPeriod?.id)
                 } else {
@@ -207,7 +204,7 @@ struct HomeView: View {
         }
 
         if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-            let t: GlassEffectTransition = reduceMotion ? .identity : .matchedGeometry
+            let t: GlassEffectTransition = .identity
             return t
         } else {
             return nil
@@ -271,6 +268,35 @@ struct HomeView: View {
         } else {
             menu
         }
+    }
+
+    private func addExpenseToolbarGlassControl(for summary: BudgetSummary?) -> some View {
+        let activeBudgetID = summary?.id
+        let isEnabled = hasActiveBudget && activeBudgetID != nil
+
+        return Menu {
+            if let budgetID = activeBudgetID {
+                Button("Add Planned Expense") {
+                    triggerAddExpense(.budgetDetailsRequestAddPlannedExpense, budgetID: budgetID)
+                }
+                Button("Add Variable Expense") {
+                    triggerAddExpense(.budgetDetailsRequestAddVariableExpense, budgetID: budgetID)
+                }
+            }
+        } label: {
+            HeaderMenuGlassLabel(
+                systemImage: "plus",
+                glassNamespace: toolbarGlassNamespace,
+                glassID: HomeToolbarGlassIdentifiers.addExpense,
+                glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
+                transition: toolbarGlassTransition
+            )
+        }
+        .modifier(HideMenuIndicatorIfPossible())
+        .accessibilityLabel("Add Expense")
+        .opacity(isEnabled ? 1 : 0)
+        .allowsHitTesting(isEnabled)
+        .accessibilityHidden(!isEnabled)
     }
 
     private func addExpenseToolbarMenu() -> some View {


### PR DESCRIPTION
## Summary
- keep the Home add-expense control inside the iOS 26 glass toolbar container and fade it when disabled so the union membership stays stable
- switch the glass transition to identity for translucency-capable platforms to prevent unwanted matched-geometry choreography

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e59fb090d8832c8afeb3ac80a9ce41