### PR TITLE
Stabilize home toolbar glass transitions

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -609,10 +609,17 @@ struct RootHeaderGlassControl<Content: View>: View {
             if background == .clear {
                 let side = capabilities.supportsOS26Translucency ? max(iconSide, d) : fallbackSide
 
-                content
-                    .frame(width: side, height: side)
-                    .background(Color.clear)
-                    .contentShape(Circle())
+                if capabilities.supportsOS26Translucency, #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+                    content
+                        .frame(width: side, height: side)
+                        .glassEffect(.regular.interactive(), in: Circle())
+                        .contentShape(Circle())
+                } else {
+                    content
+                        .frame(width: side, height: side)
+                        .background(Color.clear)
+                        .contentShape(Circle())
+                }
             } else {
 
 #if os(iOS) || targetEnvironment(macCatalyst)


### PR DESCRIPTION
## Summary
- track the active budget ID in HomeView state to drive toolbar button updates
- gate the add-expense control on the cached ID and adjust glass transitions to materialize instead of matching geometry
- give clear icon buttons their own glass effect shape before being merged by the container

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5a54accd4832c91965206a17bd5de