### PR TITLE
Stabilize Home toolbar glass transitions

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -609,10 +609,28 @@ struct RootHeaderGlassControl<Content: View>: View {
             if background == .clear {
                 let side = capabilities.supportsOS26Translucency ? max(iconSide, d) : fallbackSide
 
-                content
+                let icon = content
                     .frame(width: side, height: side)
-                    .background(Color.clear)
                     .contentShape(Circle())
+
+#if os(iOS) || targetEnvironment(macCatalyst)
+                if capabilities.supportsOS26Translucency {
+                    if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+                        icon
+                            .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
+                            .contentShape(Circle())
+                    } else {
+                        icon
+                            .background(Color.clear)
+                    }
+                } else {
+                    icon
+                        .background(Color.clear)
+                }
+#else
+                icon
+                    .background(Color.clear)
+#endif
             } else {
 
 #if os(iOS) || targetEnvironment(macCatalyst)

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -43,6 +43,9 @@ struct HomeView: View {
     @State private var isPresentingManageCategories: Bool = false
     @Namespace private var toolbarGlassNamespace
     @State private var hasActiveBudget: Bool = false
+    @State private var toolbarBudgetID: NSManagedObjectID?
+    @State private var toolbarBudgetIDChanged: Bool = false
+    @State private var toolbarGlyphIsEnteringOrExiting: Bool = false
 
     // MARK: Body
     @EnvironmentObject private var themeManager: ThemeManager
@@ -83,12 +86,20 @@ struct HomeView: View {
 
                         calendarToolbarMenu()
 
-                        if hasActiveBudget, let active = actionableSummaryForSelectedPeriod {
-                            addExpenseToolbarMenu(for: active.id)
-                                .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                        if hasActiveBudget, let id = toolbarBudgetID {
+                            addExpenseToolbarMenu(budgetID: id)
+                                .transaction { transaction in
+                                    if !toolbarBudgetIDChanged {
+                                        transaction.animation = nil
+                                    }
+                                }
                         }
                     }
-                    .animation(nil, value: actionableSummaryForSelectedPeriod?.id)
+                    .transaction { transaction in
+                        if !toolbarBudgetIDChanged {
+                            transaction.animation = nil
+                        }
+                    }
                 } else {
                     // Legacy / older OS
                     if let periodSummary = actionableSummaryForSelectedPeriod {
@@ -99,8 +110,13 @@ struct HomeView: View {
 
                     calendarToolbarMenu()
 
-                    if let active = actionableSummaryForSelectedPeriod {
-                        addExpenseToolbarMenu(for: active.id)
+                    if hasActiveBudget, let id = toolbarBudgetID {
+                        addExpenseToolbarMenu(budgetID: id)
+                            .transaction { transaction in
+                                if !toolbarBudgetIDChanged {
+                                    transaction.animation = nil
+                                }
+                            }
                     }
                 }
             }
@@ -109,23 +125,16 @@ struct HomeView: View {
             CoreDataService.shared.ensureLoaded()
             vm.startIfNeeded()
         }
-        .onAppear { hasActiveBudget = actionableSummaryForSelectedPeriod != nil }
-        .ub_onChange(of: actionableSummaryForSelectedPeriod?.id) { _ in
-            let newHasActiveBudget = actionableSummaryForSelectedPeriod != nil
-            guard newHasActiveBudget != hasActiveBudget else { return }
-
-            if capabilities.supportsOS26Translucency && !reduceMotion {
-                withAnimation(periodAdjustmentAnimation) { hasActiveBudget = newHasActiveBudget }
-            } else {
-                hasActiveBudget = newHasActiveBudget
-            }
-        }
+        .onAppear { updateToolbarState(shouldAnimatePresenceChange: false) }
+        .ub_onChange(of: vm.state) { _ in updateToolbarState() }
+        .ub_onChange(of: actionableSummaryForSelectedPeriod?.id) { _ in updateToolbarState() }
         // Temporarily disable automatic refresh on every Core Data save to
         // prevent re-entrant view reconstruction and load() loops. Explicit
         // onSaved callbacks already trigger refreshes where it matters.
         .ub_onChange(of: budgetPeriodRawValue) { newValue in
             let newPeriod = BudgetPeriod(rawValue: newValue) ?? .monthly
             vm.updateBudgetPeriod(to: newPeriod)
+            updateToolbarState()
         }
 
         // MARK: ADD SHEET — present new budget UI for the selected period
@@ -201,17 +210,60 @@ struct HomeView: View {
     }
 
     // MARK: Toolbar Actions
-    private var toolbarGlassTransition: Any? {
-        guard capabilities.supportsOS26Translucency else {
-            return nil
+    private func updateToolbarState(shouldAnimatePresenceChange: Bool = true) {
+        let newSummaryID = actionableSummaryForSelectedPeriod?.id
+        let newHasActiveBudget = newSummaryID != nil
+        let previousHasActiveBudget = hasActiveBudget
+
+        let presenceChanged = newHasActiveBudget != previousHasActiveBudget
+        let budgetIDChanged = toolbarBudgetID != newSummaryID
+
+        if budgetIDChanged {
+            toolbarBudgetID = newSummaryID
         }
 
-        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
-            let t: GlassEffectTransition = reduceMotion ? .identity : .matchedGeometry
-            return t
+        toolbarBudgetIDChanged = budgetIDChanged
+        let shouldAnimateGlyphTransition = presenceChanged && shouldAnimatePresenceChange
+        toolbarGlyphIsEnteringOrExiting = shouldAnimateGlyphTransition
+
+        guard presenceChanged else { return }
+
+        let applyPresenceChange = { hasActiveBudget = newHasActiveBudget }
+
+        if shouldAnimatePresenceChange && capabilities.supportsOS26Translucency && !reduceMotion {
+            withAnimation(periodAdjustmentAnimation) { applyPresenceChange() }
         } else {
-            return nil
+            applyPresenceChange()
         }
+    }
+
+    @available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *)
+    private func toolbarGlassTransition(isEnteringOrExiting: Bool) -> GlassEffectTransition {
+        guard isEnteringOrExiting, !reduceMotion else { return .identity }
+
+        return .matchedGeometry.animation(
+            .spring(response: 0.28, dampingFraction: 0.9, blendDuration: 0.1)
+        )
+    }
+
+    private func toolbarAddMenuGlassTransition() -> Any? {
+        guard capabilities.supportsOS26Translucency else { return nil }
+
+        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            return toolbarGlassTransition(isEnteringOrExiting: toolbarGlyphIsEnteringOrExiting)
+        }
+
+        return nil
+    }
+
+    private func toolbarIdentityGlassTransition() -> Any? {
+        guard capabilities.supportsOS26Translucency else { return nil }
+
+        if #available(iOS 26.0, macOS 26.0, macCatalyst 26.0, *) {
+            return GlassEffectTransition.identity
+        }
+
+        return nil
     }
 
     private var periodAdjustmentAnimation: Animation {
@@ -245,7 +297,7 @@ struct HomeView: View {
                     glassNamespace: toolbarGlassNamespace,
                     glassID: HomeToolbarGlassIdentifiers.calendar,
                     glassUnionID: HomeGlassUnionID.main.rawValue,
-                    glassTransition: toolbarGlassTransition,
+                    glassTransition: toolbarIdentityGlassTransition(),
                     background: .clear
                 )
                 .accessibilityLabel(budgetPeriod.displayName)
@@ -255,7 +307,7 @@ struct HomeView: View {
                     glassNamespace: toolbarGlassNamespace,
                     glassID: HomeToolbarGlassIdentifiers.calendar,
                     glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                    transition: toolbarGlassTransition
+                    transition: toolbarIdentityGlassTransition()
                 )
                 .accessibilityLabel(budgetPeriod.displayName)
             }
@@ -283,14 +335,14 @@ struct HomeView: View {
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
                 glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                transition: toolbarGlassTransition
+                transition: toolbarAddMenuGlassTransition()
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
         .accessibilityLabel("Add Expense")
     }
 
-    private func addExpenseToolbarMenu(for budgetID: NSManagedObjectID) -> some View {
+    private func addExpenseToolbarMenu(budgetID: NSManagedObjectID) -> some View {
         Menu {
             Button("Add Planned Expense") {
                 triggerAddExpense(.budgetDetailsRequestAddPlannedExpense, budgetID: budgetID)
@@ -304,7 +356,7 @@ struct HomeView: View {
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.addExpense,
                 glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                transition: toolbarGlassTransition
+                transition: toolbarAddMenuGlassTransition()
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -324,7 +376,7 @@ struct HomeView: View {
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.options,
                 glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                transition: toolbarGlassTransition
+                transition: toolbarIdentityGlassTransition()
             )
         }
         .modifier(HideMenuIndicatorIfPossible())
@@ -352,7 +404,7 @@ struct HomeView: View {
                 glassNamespace: toolbarGlassNamespace,
                 glassID: HomeToolbarGlassIdentifiers.options,
                 glassUnionID: capabilities.supportsOS26Translucency ? HomeGlassUnionID.main.rawValue : nil,
-                transition: toolbarGlassTransition
+                transition: toolbarIdentityGlassTransition()
             )
         }
         .modifier(HideMenuIndicatorIfPossible())


### PR DESCRIPTION
## Summary
- cache the active budget ID in HomeView and centralize toolbar state updates
- gate glass transitions to real glyph entrance/exit and disable implicit animations when IDs stay stable
- ensure clear toolbar icons contribute to the glass effect capsule

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a8a42958832ca8d4667ff8c285d9